### PR TITLE
Allow ActiveSupport 4.2+

### DIFF
--- a/dor-services-client.gemspec
+++ b/dor-services-client.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activesupport', '~> 5.0'
+  spec.add_dependency 'activesupport', '>= 4.2', '< 6'
   spec.add_dependency 'faraday', '~> 0.15'
 
   spec.add_development_dependency 'bundler', '~> 1.17'


### PR DESCRIPTION
This should allow us to use the client in dor-services, which has to support activesupport 4.2 (until hydrus is upgraded to Rails 5)