### PR TITLE
Return client class upon running `#configure`

### DIFF
--- a/lib/dor/services/client.rb
+++ b/lib/dor/services/client.rb
@@ -55,6 +55,8 @@ module Dor
           instance.password = password
           # Force connection to be re-established when `.configure` is called
           instance.connection = nil
+
+          self
         end
 
         delegate :objects, :files, :workflow, :workspace, :release_tags, to: :instance

--- a/spec/dor/services/client_spec.rb
+++ b/spec/dor/services/client_spec.rb
@@ -75,6 +75,14 @@ RSpec.describe Dor::Services::Client do
     end
   end
 
+  describe '#configure' do
+    subject(:client) { described_class.configure(url: 'https://dor-services.example.com') }
+
+    it 'returns Client class' do
+      expect(client).to eq Dor::Services::Client
+    end
+  end
+
   context 'when passed a username and password' do
     before do
       described_class.configure(url: 'https://dor-services.example.com',


### PR DESCRIPTION
This allows code such as the following:

```ruby
def do_a_thing
  client.register(foo: 'bar')
end

def do_another_thing
  client.initialize_workflow(baz: 'quux')
end

private

def client
  @client ||= Dor::Services::Client.configure(url: 'http://example.edu/api/v1')
end
```

Whereas currently `#configure` returns `nil`