### PR TITLE
Move current_version to sdr

### DIFF
--- a/dor-services-client.gemspec
+++ b/dor-services-client.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport', '>= 4.2', '< 6'
+  spec.add_dependency 'deprecation'
   spec.add_dependency 'faraday', '~> 0.15'
   spec.add_dependency 'nokogiri', '~> 1.8'
 

--- a/lib/dor/services/client.rb
+++ b/lib/dor/services/client.rb
@@ -9,6 +9,7 @@ require 'dor/services/client/versioned_service'
 require 'dor/services/client/files'
 require 'dor/services/client/objects'
 require 'dor/services/client/release_tags'
+require 'dor/services/client/sdr'
 require 'dor/services/client/workflow'
 require 'dor/services/client/workspace'
 
@@ -30,6 +31,10 @@ module Dor
 
       def objects
         @objects ||= Objects.new(connection: connection, version: DEFAULT_VERSION)
+      end
+
+      def sdr
+        @sdr ||= SDR.new(connection: connection, version: DEFAULT_VERSION)
       end
 
       def files
@@ -123,7 +128,6 @@ module Dor
 
         # Notify goobi system of a new object
         delegate :notify_goobi, to: :objects
-
       end
 
       # Gets the current version number for the object

--- a/lib/dor/services/client/objects.rb
+++ b/lib/dor/services/client/objects.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
 require 'nokogiri'
+require 'deprecation'
 
 module Dor
   module Services
     class Client
       # API calls that are about a repository object
       class Objects < VersionedService
+        extend Deprecation
+
         # Creates a new object in DOR
         # @return [HashWithIndifferentAccess] the response, which includes a :pid
         def register(params:)
@@ -46,16 +49,9 @@ module Dor
         # @raise [MalformedResponse] when the response is not parseable.
         # @return [Integer] the current version
         def current_version(object:)
-          xml = current_version_response(object: object)
-          begin
-            doc = Nokogiri::XML xml
-            raise if doc.root.name != 'currentVersion'
-
-            return Integer(doc.text)
-          rescue StandardError
-            raise MalformedResponse, "Unable to parse XML from current_version API call: #{xml}"
-          end
+          SDR.new(connection: connection, version: api_version).current_version(object: object)
         end
+        deprecation_deprecate current_version: 'Use Dor::Client.sdr.current_version instead'
 
         private
 
@@ -73,22 +69,6 @@ module Dor
           return resp.body if resp.success?
 
           raise UnexpectedResponse, "#{resp.reason_phrase}: #{resp.status} (#{resp.body})"
-        end
-
-        # make the request to the server for the currentVersion xml
-        # @raises [UnexpectedResponse] on an unsuccessful response from the server
-        # @returns [String] the raw xml from the server
-        def current_version_response(object:)
-          resp = connection.get do |req|
-            req.url current_version_path(object: object)
-          end
-          return resp.body if resp.success?
-
-          raise UnexpectedResponse, "#{resp.reason_phrase}: #{resp.status} (#{resp.body}) for #{object}"
-        end
-
-        def current_version_path(object:)
-          "#{api_version}/sdr/objects/#{object}/current_version"
         end
       end
     end

--- a/lib/dor/services/client/sdr.rb
+++ b/lib/dor/services/client/sdr.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Dor
+  module Services
+    class Client
+      # API calls that are about preserved objects
+      class SDR < VersionedService
+        # Gets the current version number for the object
+        # @param object [String] the pid for the object
+        # @raise [UnexpectedResponse] when the response is not successful.
+        # @raise [MalformedResponse] when the response is not parseable.
+        # @return [Integer] the current version
+        def current_version(object:)
+          xml = current_version_response(object: object)
+          begin
+            doc = Nokogiri::XML xml
+            raise if doc.root.name != 'currentVersion'
+
+            return Integer(doc.text)
+          rescue StandardError
+            raise MalformedResponse, "Unable to parse XML from current_version API call: #{xml}"
+          end
+        end
+
+        private
+
+        # make the request to the server for the currentVersion xml
+        # @raises [UnexpectedResponse] on an unsuccessful response from the server
+        # @returns [String] the raw xml from the server
+        def current_version_response(object:)
+          resp = connection.get do |req|
+            req.url current_version_path(object: object)
+          end
+          return resp.body if resp.success?
+
+          raise UnexpectedResponse, "#{resp.reason_phrase}: #{resp.status} (#{resp.body}) for #{object}"
+        end
+
+        def current_version_path(object:)
+          "#{api_version}/sdr/objects/#{object}/current_version"
+        end
+      end
+    end
+  end
+end

--- a/spec/dor/services/client/objects_spec.rb
+++ b/spec/dor/services/client/objects_spec.rb
@@ -101,27 +101,8 @@ RSpec.describe Dor::Services::Client::Objects do
       let(:body) { '<currentVersion>2</currentVersion>' }
 
       it 'returns true' do
+        expect(Deprecation).to receive(:warn)
         expect(request).to eq 2
-      end
-    end
-
-    context 'when API request responds with bad xml' do
-      let(:status) { 200 }
-      let(:body) { '<foo><bar>' }
-
-      it 'raises an error' do
-        expect { request }.to raise_error(Dor::Services::Client::MalformedResponse,
-                                          'Unable to parse XML from current_version API call: <foo><bar>')
-      end
-    end
-
-    context 'when API request fails' do
-      let(:status) { [500, 'internal server error'] }
-      let(:body) { 'broken' }
-
-      it 'raises an error' do
-        expect { request }.to raise_error(Dor::Services::Client::UnexpectedResponse,
-                                          'internal server error: 500 (broken) for druid:1234')
       end
     end
   end

--- a/spec/dor/services/client/sdr_spec.rb
+++ b/spec/dor/services/client/sdr_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec.describe Dor::Services::Client::SDR do
+  before do
+    Dor::Services::Client.configure(url: 'https://dor-services.example.com')
+  end
+  let(:connection) { Dor::Services::Client.instance.send(:connection) }
+  subject(:client) { described_class.new(connection: connection, version: 'v1') }
+
+  describe '#current_version' do
+    let(:pid) { 'druid:1234' }
+    subject(:request) { client.current_version(object: pid) }
+    before do
+      stub_request(:get, 'https://dor-services.example.com/v1/sdr/objects/druid:1234/current_version')
+        .to_return(status: status, body: body)
+    end
+
+    context 'when API request succeeds' do
+      let(:status) { 200 }
+      let(:body) { '<currentVersion>2</currentVersion>' }
+
+      it 'returns true' do
+        expect(request).to eq 2
+      end
+    end
+
+    context 'when API request responds with bad xml' do
+      let(:status) { 200 }
+      let(:body) { '<foo><bar>' }
+
+      it 'raises an error' do
+        expect { request }.to raise_error(Dor::Services::Client::MalformedResponse,
+                                          'Unable to parse XML from current_version API call: <foo><bar>')
+      end
+    end
+
+    context 'when API request fails' do
+      let(:status) { [500, 'internal server error'] }
+      let(:body) { 'broken' }
+
+      it 'raises an error' do
+        expect { request }.to raise_error(Dor::Services::Client::UnexpectedResponse,
+                                          'internal server error: 500 (broken) for druid:1234')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This will allow us to have a current_version call that references the VersionMetadataDS
datastream