### PR TITLE
Change how `Client#Object` handles HTTP 404 responses

### DIFF
--- a/lib/dor/services/client.rb
+++ b/lib/dor/services/client.rb
@@ -14,8 +14,11 @@ module Dor
     class Client
       class Error < StandardError; end
 
+      # Error that is raised when the remote server returns a 404 Not Found
+      class NotFoundResponse < Error; end
+
       # Error that is raised when the remote server returns some unexpected response
-      # this could be any 4xx or 5xx status.
+      # this could be any 4xx or 5xx status
       class UnexpectedResponse < Error; end
 
       # Error that is raised when the remote server returns some unparsable response

--- a/lib/dor/services/client/object.rb
+++ b/lib/dor/services/client/object.rb
@@ -40,6 +40,7 @@ module Dor
         end
 
         # Publish a new object
+        # @raise [NotFoundResponse] when the response is a 404 (object not found)
         # @raise [UnexpectedResponse] when the response is not successful.
         # @return [boolean] true on success
         def publish
@@ -48,24 +49,25 @@ module Dor
           end
           return true if resp.success?
 
-          raise UnexpectedResponse, "#{resp.reason_phrase}: #{resp.status} (#{resp.body})"
+          raise_exception_based_on_response!(resp)
         end
 
         # Notify the external Goobi system for a new object that was registered in DOR
+        # @raise [NotFoundResponse] when the response is a 404 (object not found)
         # @raise [UnexpectedResponse] when the response is not successful.
         # @return [boolean] true on success
         def notify_goobi
           resp = connection.post do |req|
             req.url "#{object_path}/notify_goobi"
           end
-          return true
+          return true if resp.success?
 
-          raise UnexpectedResponse, "#{resp.reason_phrase}: #{resp.status} (#{resp.body})"
+          raise_exception_based_on_response!(resp)
         end
 
         # Get the current_version for a DOR object. This comes from Dor::VersionMetadataDS
-        # @raise [UnexpectedResponse] when the response is not successful.
         # @raise [NotFoundResponse] when the response is a 404 (object not found)
+        # @raise [UnexpectedResponse] when the response is not successful.
         # @return [String] the version identifier
         def current_version
           resp = connection.get do |req|
@@ -73,15 +75,14 @@ module Dor
           end
           return resp.body if resp.success?
 
-          raise NotFoundResponse, "#{resp.reason_phrase}: #{resp.status} (#{resp.body})" if resp.status == 404
-
-          raise UnexpectedResponse, "#{resp.reason_phrase}: #{resp.status} (#{resp.body})"
+          raise_exception_based_on_response!(resp)
         end
 
         # Open new version for an object
         # @param params [Hash] optional params (see dor-services-app)
-        # @raise [UnexpectedResponse] when the response is not successful.
         # @raise [MalformedResponse] when the response is not parseable.
+        # @raise [NotFoundResponse] when the response is a 404 (object not found)
+        # @raise [UnexpectedResponse] when the response is not successful.
         # @return [String] the current version
         def open_new_version(**params)
           version = open_new_version_response(**params)
@@ -92,6 +93,7 @@ module Dor
 
         # Close current version for an object
         # @param params [Hash] optional params (see dor-services-app)
+        # @raise [NotFoundResponse] when the response is a 404 (object not found)
         # @raise [UnexpectedResponse] when the response is not successful.
         # @return [String] a message confirming successful closing
         def close_version(**params)
@@ -102,7 +104,7 @@ module Dor
           end
           return resp.body if resp.success?
 
-          raise UnexpectedResponse, "#{resp.reason_phrase}: #{resp.status} (#{resp.body})"
+          raise_exception_based_on_response!(resp)
         end
 
         private
@@ -113,8 +115,14 @@ module Dor
           "#{api_version}/objects/#{object_id}"
         end
 
+        def raise_exception_based_on_response!(response)
+          raise (response.status == 404 ? NotFoundResponse : UnexpectedResponse),
+                "#{response.reason_phrase}: #{response.status} (#{response.body})"
+        end
+
         # Make request to server to open a new version
         # @param params [Hash] optional params (see dor-services-app)
+        # @raise [NotFoundResponse] when the response is a 404 (object not found)
         # @raises [UnexpectedResponse] on an unsuccessful response from the server
         # @returns [String] the plain text from the server
         def open_new_version_response(**params)
@@ -125,7 +133,7 @@ module Dor
           end
           return resp.body if resp.success?
 
-          raise UnexpectedResponse, "#{resp.reason_phrase}: #{resp.status} (#{resp.body})"
+          raise_exception_based_on_response!(resp)
         end
 
         def open_new_version_path

--- a/spec/dor/services/client/object_spec.rb
+++ b/spec/dor/services/client/object_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe Dor::Services::Client::Object do
 
       it 'raises an UnexpectedResponse error' do
         expect { request }.to raise_error(Dor::Services::Client::UnexpectedResponse,
-                                          'internal server error: 500 (broken) for druid:1234')
+                                          'internal server error: 500 (broken)')
       end
     end
   end
@@ -220,7 +220,7 @@ RSpec.describe Dor::Services::Client::Object do
 
       it 'raises an UnexpectedResponse error' do
         expect { request }.to raise_error(Dor::Services::Client::UnexpectedResponse,
-                                          'internal server error: 500 (broken) for druid:1234')
+                                          'internal server error: 500 (broken)')
       end
     end
   end

--- a/spec/dor/services/client/object_spec.rb
+++ b/spec/dor/services/client/object_spec.rb
@@ -56,6 +56,14 @@ RSpec.describe Dor::Services::Client::Object do
       end
     end
 
+    context 'when API request returns 404' do
+      let(:status) { [404, 'not found'] }
+
+      it 'raises a NotFoundResponse exception' do
+        expect { request }.to raise_error(Dor::Services::Client::NotFoundResponse, 'not found: 404 ()')
+      end
+    end
+
     context 'when API request fails' do
       let(:status) { [409, 'conflict'] }
 
@@ -67,6 +75,7 @@ RSpec.describe Dor::Services::Client::Object do
 
   describe '#notify_goobi' do
     subject(:request) { client.notify_goobi }
+
     before do
       stub_request(:post, 'https://dor-services.example.com/v1/objects/druid:1234/notify_goobi')
         .to_return(status: status)
@@ -77,6 +86,14 @@ RSpec.describe Dor::Services::Client::Object do
 
       it 'returns true' do
         expect(request).to be true
+      end
+    end
+
+    context 'when API request returns 404' do
+      let(:status) { [404, 'not found'] }
+
+      it 'raises a NotFoundResponse exception' do
+        expect { request }.to raise_error(Dor::Services::Client::NotFoundResponse, 'not found: 404 ()')
       end
     end
 
@@ -92,24 +109,32 @@ RSpec.describe Dor::Services::Client::Object do
   describe '#current_version' do
     subject(:request) { client.current_version }
 
+    before do
+      stub_request(:get, 'https://dor-services.example.com/v1/objects/druid:1234/versions/current')
+        .to_return(status: status, body: body)
+    end
+
     context 'when API request succeeds' do
       let(:status) { 200 }
-      before do
-        stub_request(:get, 'https://dor-services.example.com/v1/objects/druid:1234/versions/current')
-          .to_return(status: status, body: '2')
-      end
+      let(:body) { '2' }
 
       it 'returns the value' do
         expect(request).to eq '2'
       end
     end
 
+    context 'when API request returns 404' do
+      let(:status) { [404, 'not found'] }
+      let(:body) { '' }
+
+      it 'raises a NotFoundResponse exception' do
+        expect { request }.to raise_error(Dor::Services::Client::NotFoundResponse, 'not found: 404 ()')
+      end
+    end
+
     context 'when API request fails' do
       let(:status) { [401, 'unauthorized'] }
-      before do
-        stub_request(:get, 'https://dor-services.example.com/v1/objects/druid:1234/versions/current')
-          .to_return(status: status)
-      end
+      let(:body) { '' }
 
       it 'raises an error' do
         expect { request }.to raise_error(Dor::Services::Client::UnexpectedResponse, 'unauthorized: 401 ()')
@@ -165,6 +190,15 @@ RSpec.describe Dor::Services::Client::Object do
       end
     end
 
+    context 'when API request returns 404' do
+      let(:status) { [404, 'not found'] }
+      let(:body) { '' }
+
+      it 'raises a NotFoundResponse exception' do
+        expect { request }.to raise_error(Dor::Services::Client::NotFoundResponse, 'not found: 404 ()')
+      end
+    end
+
     context 'when API request fails' do
       let(:status) { [500, 'internal server error'] }
       let(:body) { 'broken' }
@@ -211,6 +245,15 @@ RSpec.describe Dor::Services::Client::Object do
 
       it 'returns confirmation message' do
         expect(request).to eq body
+      end
+    end
+
+    context 'when API request returns 404' do
+      let(:status) { [404, 'not found'] }
+      let(:body) { '' }
+
+      it 'raises a NotFoundResponse exception' do
+        expect { request }.to raise_error(Dor::Services::Client::NotFoundResponse, 'not found: 404 ()')
       end
     end
 


### PR DESCRIPTION
Fixes #39

This PR includes:

* Add new exception class for 404 Not Found responses 
* Intermediate refactoring that coerces `Object` instance methods into the same shape, allowing a further refactoring
* Complete refactoring: this change ensures that all API calls made from the `Client#Object` class handle 404s by raising a custom exception. When dor-services-app responds with a 404, this is not an unexpected response when the object does not exist. This is how the API should behave. Making this change lets downstream users reason more confidently when the client returns a response.
  * This change also expands the ability to handle 404s beyond just the `#current_version` call.

