### PR TITLE
Allow client to cache object instance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
-
-# single test suite, non-parallel build.
-
 env:
   global:
     - CC_TEST_REPORTER_ID=47b57fbbf65654b17f33b6ff4a108ce2abed31a86468033f20eb4d4e9e09935a
@@ -8,7 +5,6 @@ language: ruby
 cache: bundler
 rvm:
   - 2.5.3
-before_install: gem install bundler -v 1.17.1
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter

--- a/dor-services-client.gemspec
+++ b/dor-services-client.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday', '~> 0.15'
   spec.add_dependency 'nokogiri', '~> 1.8'
 
-  spec.add_development_dependency 'bundler', '~> 1.17'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.61.0'

--- a/lib/dor/services/client.rb
+++ b/lib/dor/services/client.rb
@@ -28,10 +28,21 @@ module Dor
 
       include Singleton
 
+      # @param object_identifier [String] the pid for the object
+      # @raise [ArgumentError] when `object_identifier` is `nil`
+      # @return [Dor::Services::Client::Object] an instance of the `Client::Object` class
       def object(object_identifier)
-        Object.new(connection: connection, version: DEFAULT_VERSION, object_id: object_identifier)
+        raise ArgumentError, '`object_identifier` argument cannot be `nil` in call to `#object(object_identifier)' if object_identifier.nil?
+
+        # Return memoized object instance if object identifier value is the same
+        # This allows us to test the client more easily in downstream codebases,
+        # opening up stubbing without requiring `any_instance_of`
+        return @object if @object&.object_id == object_identifier
+
+        @object = Object.new(connection: connection, version: DEFAULT_VERSION, object_id: object_identifier)
       end
 
+      # @return [Dor::Services::Client::Objects] an instance of the `Client::Objects` class
       def objects
         @objects ||= Objects.new(connection: connection, version: DEFAULT_VERSION)
       end

--- a/lib/dor/services/client/object.rb
+++ b/lib/dor/services/client/object.rb
@@ -11,6 +11,8 @@ module Dor
     class Client
       # API calls that are about a repository object
       class Object < VersionedService
+        attr_reader :object_id
+
         # @param object_id [String] the pid for the object
         def initialize(connection:, version:, object_id:)
           raise ArgumentError, "The `object_id` parameter must be an identifier string: #{object_id.inspect}" unless object_id.is_a?(String)
@@ -108,8 +110,6 @@ module Dor
         end
 
         private
-
-        attr_reader :object_id
 
         def object_path
           "#{api_version}/objects/#{object_id}"

--- a/spec/dor/services/client/object_spec.rb
+++ b/spec/dor/services/client/object_spec.rb
@@ -10,6 +10,12 @@ RSpec.describe Dor::Services::Client::Object do
 
   subject(:client) { described_class.new(connection: connection, version: 'v1', object_id: pid) }
 
+  describe '#object_id' do
+    it 'returns the injected pid' do
+      expect(client.object_id).to eq pid
+    end
+  end
+
   describe '#files' do
     it 'returns an instance of Client::Files' do
       expect(client.files).to be_instance_of Dor::Services::Client::Files

--- a/spec/dor/services/client_spec.rb
+++ b/spec/dor/services/client_spec.rb
@@ -5,22 +5,42 @@ RSpec.describe Dor::Services::Client do
     expect(Dor::Services::Client::VERSION).not_to be nil
   end
 
-  subject(:client) { described_class.instance }
-
   context 'once configured' do
     before do
       described_class.configure(url: 'https://dor-services.example.com')
     end
 
     describe '.object' do
+      let(:object_id) { 'druid:123' }
+
+      context 'with a nil object_id value' do
+        let(:object_id) { nil }
+
+        it 'raises an ArgumentError' do
+          expect { described_class.object(object_id) }.to raise_error(ArgumentError)
+        end
+      end
+
       it 'returns an instance of Client::Object' do
-        expect(described_class.object('druid:123')).to be_instance_of Dor::Services::Client::Object
+        expect(described_class.object(object_id)).to be_instance_of Dor::Services::Client::Object
+      end
+
+      it 'returns the memoized instance when called again' do
+        expect(described_class.object(object_id)).to eq described_class.object(object_id)
+      end
+
+      it 'refreshes the memoized instance when called with a different identifier'  do
+        expect(described_class.object(object_id)).not_to eq described_class.object('druid:1234')
       end
     end
 
     describe '.objects' do
       it 'returns an instance of Client::Objects' do
         expect(described_class.objects).to be_instance_of Dor::Services::Client::Objects
+      end
+
+      it 'returns the memoized instance when called again' do
+        expect(described_class.objects).to eq described_class.objects
       end
     end
   end


### PR DESCRIPTION
Only do this if the `object_identifier` argument is equivalent to the memoized Object instance `object_id` value.