### PR TITLE
Rename object_id to object_identifier across the board

### DIFF
--- a/lib/dor/services/client.rb
+++ b/lib/dor/services/client.rb
@@ -37,9 +37,9 @@ module Dor
         # Return memoized object instance if object identifier value is the same
         # This allows us to test the client more easily in downstream codebases,
         # opening up stubbing without requiring `any_instance_of`
-        return @object if @object&.object_id == object_identifier
+        return @object if @object&.object_identifier == object_identifier
 
-        @object = Object.new(connection: connection, version: DEFAULT_VERSION, object_id: object_identifier)
+        @object = Object.new(connection: connection, version: DEFAULT_VERSION, object_identifier: object_identifier)
       end
 
       # @return [Dor::Services::Client::Objects] an instance of the `Client::Objects` class

--- a/lib/dor/services/client/files.rb
+++ b/lib/dor/services/client/files.rb
@@ -5,10 +5,10 @@ module Dor
     class Client
       # API calls relating to files
       class Files < VersionedService
-        # @param object_id [String] the pid for the object
-        def initialize(connection:, version:, object_id:)
+        # @param object_identifier [String] the pid for the object
+        def initialize(connection:, version:, object_identifier:)
           super(connection: connection, version: version)
-          @object_id = object_id
+          @object_identifier = object_identifier
         end
 
         # Get the contents from the workspace
@@ -16,7 +16,7 @@ module Dor
         # @return [String] the file contents from the workspace
         def retrieve(filename:)
           resp = connection.get do |req|
-            req.url "#{api_version}/objects/#{object_id}/contents/#{filename}"
+            req.url "#{api_version}/objects/#{object_identifier}/contents/#{filename}"
           end
           return unless resp.success?
 
@@ -29,7 +29,7 @@ module Dor
         # @return [String] the file contents from the SDR
         def preserved_content(filename:, version:)
           resp = connection.get do |req|
-            req.url "#{api_version}/sdr/objects/#{object_id}/content/#{CGI.escape(filename)}?version=#{version}"
+            req.url "#{api_version}/sdr/objects/#{object_identifier}/content/#{CGI.escape(filename)}?version=#{version}"
           end
           return unless resp.success?
 
@@ -40,7 +40,7 @@ module Dor
         # @return [Array<String>] the list of filenames in the workspace
         def list
           resp = connection.get do |req|
-            req.url "#{api_version}/objects/#{object_id}/contents"
+            req.url "#{api_version}/objects/#{object_identifier}/contents"
           end
           return [] unless resp.success?
 
@@ -50,7 +50,7 @@ module Dor
 
         private
 
-        attr_reader :object_id
+        attr_reader :object_identifier
       end
     end
   end

--- a/lib/dor/services/client/object.rb
+++ b/lib/dor/services/client/object.rb
@@ -11,34 +11,34 @@ module Dor
     class Client
       # API calls that are about a repository object
       class Object < VersionedService
-        attr_reader :object_id
+        attr_reader :object_identifier
 
-        # @param object_id [String] the pid for the object
-        def initialize(connection:, version:, object_id:)
-          raise ArgumentError, "The `object_id` parameter must be an identifier string: #{object_id.inspect}" unless object_id.is_a?(String)
+        # @param object_identifier [String] the pid for the object
+        def initialize(connection:, version:, object_identifier:)
+          raise ArgumentError, "The `object_identifier` parameter must be an identifier string: #{object_identifier.inspect}" unless object_identifier.is_a?(String)
 
           super(connection: connection, version: version)
-          @object_id = object_id
+          @object_identifier = object_identifier
         end
 
         def sdr
-          @sdr ||= SDR.new(connection: connection, version: api_version, object_id: object_id)
+          @sdr ||= SDR.new(connection: connection, version: api_version, object_identifier: object_identifier)
         end
 
         def files
-          @files ||= Files.new(connection: connection, version: api_version, object_id: object_id)
+          @files ||= Files.new(connection: connection, version: api_version, object_identifier: object_identifier)
         end
 
         def workflow
-          @workflow ||= Workflow.new(connection: connection, version: api_version, object_id: object_id)
+          @workflow ||= Workflow.new(connection: connection, version: api_version, object_identifier: object_identifier)
         end
 
         def workspace
-          @workspace ||= Workspace.new(connection: connection, version: api_version, object_id: object_id)
+          @workspace ||= Workspace.new(connection: connection, version: api_version, object_identifier: object_identifier)
         end
 
         def release_tags
-          @release_tags ||= ReleaseTags.new(connection: connection, version: api_version, object_id: object_id)
+          @release_tags ||= ReleaseTags.new(connection: connection, version: api_version, object_identifier: object_identifier)
         end
 
         # Publish a new object
@@ -88,7 +88,7 @@ module Dor
         # @return [String] the current version
         def open_new_version(**params)
           version = open_new_version_response(**params)
-          raise MalformedResponse, "Version of #{object_id} is empty" if version.empty?
+          raise MalformedResponse, "Version of #{object_identifier} is empty" if version.empty?
 
           version
         end
@@ -112,7 +112,7 @@ module Dor
         private
 
         def object_path
-          "#{api_version}/objects/#{object_id}"
+          "#{api_version}/objects/#{object_identifier}"
         end
 
         def raise_exception_based_on_response!(response)

--- a/lib/dor/services/client/release_tags.rb
+++ b/lib/dor/services/client/release_tags.rb
@@ -5,10 +5,10 @@ module Dor
     class Client
       # API calls that are about a repository object
       class ReleaseTags < VersionedService
-        # @param object_id [String] the pid for the object
-        def initialize(connection:, version:, object_id:)
+        # @param object_identifier [String] the pid for the object
+        def initialize(connection:, version:, object_identifier:)
           super(connection: connection, version: version)
-          @object_id = object_id
+          @object_identifier = object_identifier
         end
 
         # Creates a new release tag for the object
@@ -27,7 +27,7 @@ module Dor
             release: release
           }
           resp = connection.post do |req|
-            req.url "#{api_version}/objects/#{object_id}/release_tags"
+            req.url "#{api_version}/objects/#{object_identifier}/release_tags"
             req.headers['Content-Type'] = 'application/json'
             req.body = params.to_json
           end
@@ -39,7 +39,7 @@ module Dor
 
         private
 
-        attr_reader :object_id
+        attr_reader :object_identifier
       end
     end
   end

--- a/lib/dor/services/client/sdr.rb
+++ b/lib/dor/services/client/sdr.rb
@@ -7,10 +7,10 @@ module Dor
     class Client
       # API calls that are about preserved objects
       class SDR < VersionedService
-        # @param object_id [String] the pid for the object
-        def initialize(connection:, version:, object_id:)
+        # @param object_identifier [String] the pid for the object
+        def initialize(connection:, version:, object_identifier:)
           super(connection: connection, version: version)
-          @object_id = object_id
+          @object_identifier = object_identifier
         end
 
         # Gets the current version number for the object
@@ -31,7 +31,7 @@ module Dor
 
         private
 
-        attr_reader :object_id
+        attr_reader :object_identifier
 
         # make the request to the server for the currentVersion xml
         # @raises [UnexpectedResponse] on an unsuccessful response from the server
@@ -42,11 +42,11 @@ module Dor
           end
           return resp.body if resp.success?
 
-          raise UnexpectedResponse, "#{resp.reason_phrase}: #{resp.status} (#{resp.body}) for #{object_id}"
+          raise UnexpectedResponse, "#{resp.reason_phrase}: #{resp.status} (#{resp.body}) for #{object_identifier}"
         end
 
         def current_version_path
-          "#{api_version}/sdr/objects/#{object_id}/current_version"
+          "#{api_version}/sdr/objects/#{object_identifier}/current_version"
         end
       end
     end

--- a/lib/dor/services/client/workflow.rb
+++ b/lib/dor/services/client/workflow.rb
@@ -5,10 +5,10 @@ module Dor
     class Client
       # API calls that are about workflow
       class Workflow < VersionedService
-        # @param object_id [String] the pid for the object
-        def initialize(connection:, version:, object_id:)
+        # @param object_identifier [String] the pid for the object
+        def initialize(connection:, version:, object_identifier:)
           super(connection: connection, version: version)
-          @object_id = object_id
+          @object_identifier = object_identifier
         end
 
         # Begin a new workflow
@@ -17,14 +17,14 @@ module Dor
         # @return nil
         def create(wf_name:)
           resp = connection.post do |req|
-            req.url "#{api_version}/objects/#{object_id}/apo_workflows/#{wf_name}"
+            req.url "#{api_version}/objects/#{object_identifier}/apo_workflows/#{wf_name}"
           end
           raise UnexpectedResponse, "#{resp.reason_phrase}: #{resp.status} (#{resp.body})" unless resp.success?
         end
 
         private
 
-        attr_reader :object_id
+        attr_reader :object_identifier
       end
     end
   end

--- a/lib/dor/services/client/workspace.rb
+++ b/lib/dor/services/client/workspace.rb
@@ -5,10 +5,10 @@ module Dor
     class Client
       # API calls that are about the DOR workspace
       class Workspace < VersionedService
-        # @param object_id [String] the pid for the object
-        def initialize(connection:, version:, object_id:)
+        # @param object_identifier [String] the pid for the object
+        def initialize(connection:, version:, object_identifier:)
           super(connection: connection, version: version)
-          @object_id = object_id
+          @object_identifier = object_identifier
         end
 
         # Initializes a new workspace
@@ -17,7 +17,7 @@ module Dor
         # @return nil
         def create(source:)
           resp = connection.post do |req|
-            req.url "#{api_version}/objects/#{object_id}/initialize_workspace"
+            req.url "#{api_version}/objects/#{object_identifier}/initialize_workspace"
             req.params['source'] = source
           end
           raise UnexpectedResponse, "#{resp.reason_phrase}: #{resp.status} (#{resp.body})" unless resp.success?
@@ -25,7 +25,7 @@ module Dor
 
         private
 
-        attr_reader :object_id
+        attr_reader :object_identifier
       end
     end
   end

--- a/spec/dor/services/client/files_spec.rb
+++ b/spec/dor/services/client/files_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Dor::Services::Client::Files do
   let(:connection) { Dor::Services::Client.instance.send(:connection) }
   let(:pid) { 'druid:ck546xs5106' }
 
-  subject(:client) { described_class.new(connection: connection, version: 'v1', object_id: pid) }
+  subject(:client) { described_class.new(connection: connection, version: 'v1', object_identifier: pid) }
 
   describe '#list' do
     subject { client.list }

--- a/spec/dor/services/client/object_spec.rb
+++ b/spec/dor/services/client/object_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe Dor::Services::Client::Object do
   let(:connection) { Dor::Services::Client.instance.send(:connection) }
   let(:pid) { 'druid:1234' }
 
-  subject(:client) { described_class.new(connection: connection, version: 'v1', object_id: pid) }
+  subject(:client) { described_class.new(connection: connection, version: 'v1', object_identifier: pid) }
 
-  describe '#object_id' do
+  describe '#object_identifier' do
     it 'returns the injected pid' do
-      expect(client.object_id).to eq pid
+      expect(client.object_identifier).to eq pid
     end
   end
 

--- a/spec/dor/services/client/release_tags_spec.rb
+++ b/spec/dor/services/client/release_tags_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Dor::Services::Client::ReleaseTags do
   let(:connection) { Dor::Services::Client.instance.send(:connection) }
   let(:pid) { 'druid:123' }
 
-  subject(:client) { described_class.new(connection: connection, version: 'v1', object_id: pid) }
+  subject(:client) { described_class.new(connection: connection, version: 'v1', object_identifier: pid) }
 
   describe '#create' do
     subject(:request) { client.create(release: true, to: 'searchworks', who: 'justin', what: 'foo') }

--- a/spec/dor/services/client/sdr_spec.rb
+++ b/spec/dor/services/client/sdr_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Dor::Services::Client::SDR do
   let(:connection) { Dor::Services::Client.instance.send(:connection) }
   let(:pid) { 'druid:1234' }
 
-  subject(:client) { described_class.new(connection: connection, version: 'v1', object_id: pid) }
+  subject(:client) { described_class.new(connection: connection, version: 'v1', object_identifier: pid) }
 
   describe '#current_version' do
     subject(:request) { client.current_version }

--- a/spec/dor/services/client/workflow_spec.rb
+++ b/spec/dor/services/client/workflow_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Dor::Services::Client::Workflow do
   let(:connection) { Dor::Services::Client.instance.send(:connection) }
   let(:pid) { 'druid:123' }
 
-  subject(:client) { described_class.new(connection: connection, version: 'v1', object_id: pid) }
+  subject(:client) { described_class.new(connection: connection, version: 'v1', object_identifier: pid) }
 
   describe '#create' do
     subject(:request) { client.create(wf_name: 'accessionWF') }

--- a/spec/dor/services/client/workspace_spec.rb
+++ b/spec/dor/services/client/workspace_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Dor::Services::Client::Workspace do
   let(:connection) { Dor::Services::Client.instance.send(:connection) }
   let(:pid) { 'druid:123' }
 
-  subject(:client) { described_class.new(connection: connection, version: 'v1', object_id: pid) }
+  subject(:client) { described_class.new(connection: connection, version: 'v1', object_identifier: pid) }
 
   describe '#create' do
     subject(:request) { client.create(source: 'abd/cwef/vwef/content') }

--- a/spec/dor/services/client_spec.rb
+++ b/spec/dor/services/client_spec.rb
@@ -11,26 +11,26 @@ RSpec.describe Dor::Services::Client do
     end
 
     describe '.object' do
-      let(:object_id) { 'druid:123' }
+      let(:object_identifier) { 'druid:123' }
 
-      context 'with a nil object_id value' do
-        let(:object_id) { nil }
+      context 'with a nil object_identifier value' do
+        let(:object_identifier) { nil }
 
         it 'raises an ArgumentError' do
-          expect { described_class.object(object_id) }.to raise_error(ArgumentError)
+          expect { described_class.object(object_identifier) }.to raise_error(ArgumentError)
         end
       end
 
       it 'returns an instance of Client::Object' do
-        expect(described_class.object(object_id)).to be_instance_of Dor::Services::Client::Object
+        expect(described_class.object(object_identifier)).to be_instance_of Dor::Services::Client::Object
       end
 
       it 'returns the memoized instance when called again' do
-        expect(described_class.object(object_id)).to eq described_class.object(object_id)
+        expect(described_class.object(object_identifier)).to eq described_class.object(object_identifier)
       end
 
       it 'refreshes the memoized instance when called with a different identifier'  do
-        expect(described_class.object(object_id)).not_to eq described_class.object('druid:1234')
+        expect(described_class.object(object_identifier)).not_to eq described_class.object('druid:1234')
       end
     end
 


### PR DESCRIPTION
Do this because object_id is used internally by Ruby to determine object identity.