### PR TITLE
Return a Moab::SignatureCatalog when no response from SDR

### DIFF
--- a/lib/dor/services/client/sdr.rb
+++ b/lib/dor/services/client/sdr.rb
@@ -31,10 +31,9 @@ module Dor
         end
 
         def signature_catalog
-          resp = connection.get do |req|
-            req.url "#{base_path}/manifest/signatureCatalog.xml"
-          end
+          resp = signature_catalog_response
 
+          return Moab::SignatureCatalog.new(digital_object_id: object_identifier, version_id: 0) if resp.status == 404
           raise UnexpectedResponse, "#{resp.reason_phrase}: #{resp.status} (#{resp.body}) for #{object_identifier}" unless resp.success?
 
           Moab::SignatureCatalog.parse resp.body
@@ -69,6 +68,12 @@ module Dor
         private
 
         attr_reader :object_identifier
+
+        def signature_catalog_response
+          connection.get do |req|
+            req.url "#{base_path}/manifest/signatureCatalog.xml"
+          end
+        end
 
         # make the request to the server for the currentVersion xml
         # @raises [UnexpectedResponse] on an unsuccessful response from the server

--- a/spec/dor/services/client/sdr_spec.rb
+++ b/spec/dor/services/client/sdr_spec.rb
@@ -77,13 +77,22 @@ RSpec.describe Dor::Services::Client::SDR do
       end
     end
 
-    context 'when API request fails' do
+    context 'when API request is not found' do
       let(:status) { [404, 'not found'] }
+      let(:body) { 'i dunno?' }
+
+      it 'returns a Moab::SignatureCatalog' do
+        expect(request).to be_kind_of Moab::SignatureCatalog
+      end
+    end
+
+    context 'when API request fails' do
+      let(:status) { [500, 'internal server error'] }
       let(:body) { 'i dunno?' }
 
       it 'raises an error' do
         expect { request }.to raise_error(Dor::Services::Client::UnexpectedResponse,
-                                          'not found: 404 (i dunno?) for druid:1234')
+                                          'internal server error: 500 (i dunno?) for druid:1234')
       end
     end
   end


### PR DESCRIPTION
When calling the signature_catalog endpoint.

This gives it parity with the old Sdr::Client#get_signature_catalog method:
https://github.com/sul-dlss/dor-services/blob/d9fca649c80e9bf26a058bc8c4c4f91cbf75d856/lib/dor/utils/sdr_client.rb#L43-L44