### PR TITLE
Remove credential-based authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ private
 
 def client
   @client ||= Dor::Services::Client.configure(url: Settings.dor_services.url,
-                                              username: Settings.dor_services.user,
-                                              password: Settings.dor_services.pass)
+                                              token: Settings.dor_services.token,
+                                              token_header: Settings.dor_services.token_header)
 end
 ```
 
-Note that the client may **not** be used without first having been configured, and the `url` keyword is **required**. The `username` and `password` arguments are optional. (If you are working in a project where the credentials are embedded in the URL, that ought to work just fine as well.)
+Note that the client may **not** be used without first having been configured, and the `url` keyword is **required**. The `token` and `token_header` arguments are optional (though when using the client with staging and production servers, you will always need to supply these in practice). For more about dor-services-app's token-based authentication, see [its README](https://github.com/sul-dlss/dor-services-app#authentication).
 
 ## API Coverage
 

--- a/spec/dor/services/client_spec.rb
+++ b/spec/dor/services/client_spec.rb
@@ -63,40 +63,30 @@ RSpec.describe Dor::Services::Client do
     end
   end
 
-  context 'when passed a username and password' do
+  context 'when passed a token and token_header' do
     before do
       described_class.configure(url: 'https://dor-services.example.com',
-                                username: username,
-                                password: password)
+                                token_header: 'X-Auth',
+                                token: '123')
     end
 
-    let(:username) { 'foo' }
-    let(:password) { 'bar' }
-
-    it 'sets the Authorization and User-Agent headers on the connection' do
+    it 'sets the token header on the connection' do
       expect(described_class.instance.send(:connection).headers).to include(
-        'Authorization' => 'Basic Zm9vOmJhcg==',
+        'X-Auth' => 'Bearer 123',
         'User-Agent' => /dor-services-client \d+\.\d+\.\d+/
       )
     end
   end
 
-  context 'when passed a username and password and a token' do
+  context 'when passed a token without a token_header' do
     before do
       described_class.configure(url: 'https://dor-services.example.com',
-                                username: username,
-                                password: password,
-                                token_header: 'X-Auth',
                                 token: '123')
     end
 
-    let(:username) { 'foo' }
-    let(:password) { 'bar' }
-
-    it 'sets the token header on the connection' do
+    it 'sets the token on the connection and uses the default authorization header' do
       expect(described_class.instance.send(:connection).headers).to include(
-        'Authorization' => 'Basic Zm9vOmJhcg==',
-        'X-Auth' => 'Bearer 123',
+        'Authorization' => 'Bearer 123',
         'User-Agent' => /dor-services-client \d+\.\d+\.\d+/
       )
     end


### PR DESCRIPTION
This is no longer supported in dor-services-app, and we believe all clients have been updated to use token-based authN

Refs sul-dlss/dor-services-app#320