### PR TITLE
Add deprecations in advance of 2.x release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,5 @@ before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
-script:
-  - bundle exec rspec
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ object_client.publish
 object_client.refresh_metadata
 object_client.notify_goobi
 object_client.version.current
-object_client.version.openeable?(**params)
+object_client.version.openable?(**params)
 object_client.version.open(**params)
 object_client.version.close(**params)
 # Get the Dublin Core XML representation

--- a/lib/dor/services/client/error_faraday_middleware.rb
+++ b/lib/dor/services/client/error_faraday_middleware.rb
@@ -3,7 +3,7 @@
 module Dor
   module Services
     class Client
-      # This wraps any faraday connection errors with dor-service-client errors
+      # This wraps any faraday connection errors with dor-services-client errors
       class ErrorFaradayMiddleware < Faraday::Response::Middleware
         def call(env)
           @app.call(env)

--- a/lib/dor/services/client/object_version.rb
+++ b/lib/dor/services/client/object_version.rb
@@ -1,10 +1,15 @@
 # frozen_string_literal: true
 
+require 'deprecation'
+
 module Dor
   module Services
     class Client
       # API calls that are about versions
       class ObjectVersion < VersionedService
+        extend Deprecation
+        self.deprecation_horizon = 'dor-services-client 2.0.0'
+
         # @param object_identifier [String] the pid for the object
         def initialize(connection:, version:, object_identifier:)
           super(connection: connection, version: version)
@@ -24,14 +29,25 @@ module Dor
           raise_exception_based_on_response!(resp)
         end
 
+        # TODO: remove this deprecation once
+        #       https://github.com/sul-dlss/dor-services-app/issues/322 is
+        #       merged and all DSC clients have moved to using `#openable?`
+        def openeable?(**params)
+          openable?(**params)
+        end
+        deprecation_deprecate openeable?: 'use version.openable? instead'
+
         # Determines if a new version can be opened for a DOR object.
         # @param params [Hash] optional params (see dor-services-app)
         # @raise [NotFoundResponse] when the response is a 404 (object not found)
         # @raise [UnexpectedResponse] when the response is not successful.
         # @return [Boolean] true if a new version can be opened
         # rubocop:disable Metrics/MethodLength
-        def openeable?(**params)
+        def openable?(**params)
           resp = connection.get do |req|
+            # TODO: correct the typo below once
+            #       https://github.com/sul-dlss/dor-services-app/issues/322 is
+            #       merged and all running DSA instances have been deployed
             req.url "#{object_path}/versions/openeable"
             req.params = params
           end

--- a/lib/dor/services/client/workflow.rb
+++ b/lib/dor/services/client/workflow.rb
@@ -6,7 +6,7 @@ module Dor
       # API calls that are about workflow
       class Workflow < VersionedService
         extend Deprecation
-        self.deprecation_horizon = 'dor-service-client version 2.0'
+        self.deprecation_horizon = 'dor-services-client version 2.0.0'
 
         # @param object_identifier [String] the pid for the object
         def initialize(connection:, version:, object_identifier:)
@@ -24,7 +24,7 @@ module Dor
           end
           raise UnexpectedResponse, "#{resp.reason_phrase}: #{resp.status} (#{resp.body})" unless resp.success?
         end
-        deprecation_deprecate create: 'Create will be removed. Use dor-workflow-service instead'
+        deprecation_deprecate create: 'Create will be removed. Use dor-workflow-client instead'
 
         private
 

--- a/lib/dor/services/client/workflows.rb
+++ b/lib/dor/services/client/workflows.rb
@@ -5,6 +5,9 @@ module Dor
     class Client
       # API calls that are about workflows
       class Workflows < VersionedService
+        extend Deprecation
+        self.deprecation_horizon = 'dor-services-client version 2.0.0'
+
         # Get the initial XML for a workflow
         # @param name [String] the name of the xml
         # @return [String] the response
@@ -18,6 +21,7 @@ module Dor
 
           raise UnexpectedResponse, "#{resp.reason_phrase}: #{resp.status} (#{resp.body})"
         end
+        deprecation_deprecate initial: 'Initial will be removed. Use dor-workflow-client instead'
       end
     end
   end

--- a/spec/dor/services/client/object_version_spec.rb
+++ b/spec/dor/services/client/object_version_spec.rb
@@ -185,11 +185,35 @@ RSpec.describe Dor::Services::Client::ObjectVersion do
   end
 
   describe '#openeable?' do
-    let(:params) { {} }
+    let(:status) { 200 }
+    let(:body) { 'true' }
 
     subject(:request) { client.openeable?(assume_accessioned: true) }
 
     before do
+      # TODO: correct the typo below once
+      #       https://github.com/sul-dlss/dor-services-app/issues/322 is
+      #       merged and all running DSA instances have been deployed
+      stub_request(:get, 'https://dor-services.example.com/v1/objects/druid:1234/versions/openeable?assume_accessioned=true')
+        .to_return(status: status, body: body)
+      allow(Deprecation).to receive(:warn)
+    end
+
+    it 'delegates to the non-deprecated form' do
+      expect(request).to be true
+      expect(Deprecation).to have_received(:warn)
+    end
+  end
+
+  describe '#openable?' do
+    let(:params) { {} }
+
+    subject(:request) { client.openable?(assume_accessioned: true) }
+
+    before do
+      # TODO: correct the typo below once
+      #       https://github.com/sul-dlss/dor-services-app/issues/322 is
+      #       merged and all running DSA instances have been deployed
       stub_request(:get, 'https://dor-services.example.com/v1/objects/druid:1234/versions/openeable?assume_accessioned=true')
         .to_return(status: status, body: body)
     end

--- a/spec/dor/services/client/workflow_spec.rb
+++ b/spec/dor/services/client/workflow_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Dor::Services::Client::Workflow do
     before do
       allow(Deprecation).to receive(:warn)
     end
-    
+
     context 'when API request succeeds' do
       before do
         stub_request(:post, 'https://dor-services.example.com/v1/objects/druid:123/apo_workflows/accessionWF')

--- a/spec/dor/services/client/workflows_spec.rb
+++ b/spec/dor/services/client/workflows_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Dor::Services::Client::Workflows do
     before do
       stub_request(:get, 'https://dor-services.example.com/v1/workflows/accessionWF/initial')
         .to_return(status: status, body: body)
+      allow(Deprecation).to receive(:warn)
     end
 
     context 'when API request succeeds' do
@@ -21,6 +22,7 @@ RSpec.describe Dor::Services::Client::Workflows do
 
       it 'gets the result' do
         expect(client.initial(name: 'accessionWF')).to eq body
+        expect(Deprecation).to have_received(:warn)
       end
     end
 
@@ -31,6 +33,7 @@ RSpec.describe Dor::Services::Client::Workflows do
       it 'raises an error' do
         expect { client.initial(name: 'accessionWF') }.to raise_error(Dor::Services::Client::UnexpectedResponse,
                                                                       'not found: 404 ()')
+        expect(Deprecation).to have_received(:warn)
       end
     end
   end


### PR DESCRIPTION
Fixes #71

Includes:
* Deprecate typo openeable? method
* Deprecate Workflows#initial method which is now handled by dor-workflow-client
* Correct typos in dor-services-client and dor-workflow-client names
* Run rubocop in CI not just rspec and remove some trailing whitespace
