### PR TITLE
Stop using dor-services-app openeable endpoint

### DIFF
--- a/lib/dor/services/client/object_version.rb
+++ b/lib/dor/services/client/object_version.rb
@@ -32,10 +32,7 @@ module Dor
         # rubocop:disable Metrics/MethodLength
         def openable?(**params)
           resp = connection.get do |req|
-            # TODO: correct the typo below once
-            #       https://github.com/sul-dlss/dor-services-app/issues/322 is
-            #       merged and all running DSA instances have been deployed
-            req.url "#{object_path}/versions/openeable"
+            req.url "#{object_path}/versions/openable"
             req.params = params
           end
 

--- a/spec/dor/services/client/object_version_spec.rb
+++ b/spec/dor/services/client/object_version_spec.rb
@@ -190,10 +190,7 @@ RSpec.describe Dor::Services::Client::ObjectVersion do
     subject(:request) { client.openable?(assume_accessioned: true) }
 
     before do
-      # TODO: correct the typo below once
-      #       https://github.com/sul-dlss/dor-services-app/issues/322 is
-      #       merged and all running DSA instances have been deployed
-      stub_request(:get, 'https://dor-services.example.com/v1/objects/druid:1234/versions/openeable?assume_accessioned=true')
+      stub_request(:get, 'https://dor-services.example.com/v1/objects/druid:1234/versions/openable?assume_accessioned=true')
         .to_return(status: status, body: body)
     end
 


### PR DESCRIPTION
It is a typo that will be nuked soon (see sul-dlss/dor-services-app#322) and the openable endpoint replaces it