### PR TITLE
Add missing virtual_objects accessor in client and correct README with updated virtual objects usage information

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,11 @@ objects_client = Dor::Services::Client.objects
 # For registering a non-existent object
 objects_client.register(params: {})
 
+# For interacting with virtual objects
+virtual_objects_client = Dor::Services::Client.virtual_objects
+
 # Create a batch of virtual objects
-objects_client.create_virtual_objects(parent_druid: '', child_druids: [''])
+virtual_objects_client.create(params: {})
 
 # For performing operations on a known, registered object
 object_client = Dor::Services::Client.object(object_identifier)

--- a/lib/dor/services/client.rb
+++ b/lib/dor/services/client.rb
@@ -66,6 +66,11 @@ module Dor
         @objects ||= Objects.new(connection: connection, version: DEFAULT_VERSION)
       end
 
+      # @return [Dor::Services::Client::VirtualObjects] an instance of the `Client::VirtualObjects` class
+      def virtual_objects
+        @virtual_objects ||= VirtualObjects.new(connection: connection, version: DEFAULT_VERSION)
+      end
+
       class << self
         # @param [String] url
         # @param [String] token a bearer token for HTTP auth
@@ -82,7 +87,7 @@ module Dor
           self
         end
 
-        delegate :objects, :object, to: :instance
+        delegate :objects, :object, :virtual_objects, to: :instance
       end
 
       attr_writer :url, :token, :token_header, :connection

--- a/spec/dor/services/client_spec.rb
+++ b/spec/dor/services/client_spec.rb
@@ -43,6 +43,16 @@ RSpec.describe Dor::Services::Client do
         expect(described_class.objects).to eq described_class.objects
       end
     end
+
+    describe '.virtual_objects' do
+      it 'returns an instance of Client::VirtualObjects' do
+        expect(described_class.virtual_objects).to be_instance_of Dor::Services::Client::VirtualObjects
+      end
+
+      it 'returns the memoized instance when called again' do
+        expect(described_class.virtual_objects).to eq described_class.virtual_objects
+      end
+    end
   end
 
   describe '#configure' do


### PR DESCRIPTION
I missed this in #89 