### PR TITLE
Deprecate the `token_header` argument to `Client.configure`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,11 @@ private
 
 def client
   @client ||= Dor::Services::Client.configure(url: Settings.dor_services.url,
-                                              token: Settings.dor_services.token,
-                                              token_header: Settings.dor_services.token_header)
+                                              token: Settings.dor_services.token)
 end
 ```
 
-Note that the client may **not** be used without first having been configured, and the `url` keyword is **required**. The `token` and `token_header` arguments are optional (though when using the client with staging and production servers, you will always need to supply these in practice). For more about dor-services-app's token-based authentication, see [its README](https://github.com/sul-dlss/dor-services-app#authentication).
+Note that the client may **not** be used without first having been configured, and the `url` keyword is **required**. The `token` argument is optional (though when using the client with staging and production servers, you will always need to supply it in practice). For more about dor-services-app's token-based authentication, see [its README](https://github.com/sul-dlss/dor-services-app#authentication).
 
 ## API Coverage
 

--- a/dor-services-client.gemspec
+++ b/dor-services-client.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport', '>= 4.2', '< 7'
   spec.add_dependency 'cocina-models', '~> 0.1.0'
+  spec.add_dependency 'deprecation'
   spec.add_dependency 'faraday', '~> 0.15'
   spec.add_dependency 'moab-versioning', '~> 4.0'
   spec.add_dependency 'nokogiri', '~> 1.8'

--- a/spec/dor/services/client_spec.rb
+++ b/spec/dor/services/client_spec.rb
@@ -65,20 +65,22 @@ RSpec.describe Dor::Services::Client do
 
   context 'when passed a token and token_header' do
     before do
+      allow(Deprecation).to receive(:warn)
       described_class.configure(url: 'https://dor-services.example.com',
                                 token_header: 'X-Auth',
                                 token: '123')
     end
 
-    it 'sets the token header on the connection' do
+    it 'ignores the supplied token header on the connection and issues a deprecation warning' do
       expect(described_class.instance.send(:connection).headers).to include(
-        'X-Auth' => 'Bearer 123',
+        described_class::TOKEN_HEADER => 'Bearer 123',
         'User-Agent' => /dor-services-client \d+\.\d+\.\d+/
       )
+      expect(Deprecation).to have_received(:warn).once
     end
   end
 
-  context 'when passed a token without a token_header' do
+  context 'when passed a token' do
     before do
       described_class.configure(url: 'https://dor-services.example.com',
                                 token: '123')
@@ -86,7 +88,7 @@ RSpec.describe Dor::Services::Client do
 
     it 'sets the token on the connection and uses the default authorization header' do
       expect(described_class.instance.send(:connection).headers).to include(
-        'Authorization' => 'Bearer 123',
+        described_class::TOKEN_HEADER => 'Bearer 123',
         'User-Agent' => /dor-services-client \d+\.\d+\.\d+/
       )
     end


### PR DESCRIPTION
And ignore it in practice now that we no longer need to support multiple authorization schemes.

Connects to #93