### PR TITLE
Remove `Object#add_constituents` now that Argo no longer uses it

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,6 @@ object_client.update_marc_record
 # Copy metadata from Symphony into descMetadata
 object_client.refresh_metadata
 
-# Add constituents to an object (virtual-merge)
-object_client.add_constituents(child_druids:)
-
 # Send a notification to goobi
 object_client.notify_goobi
 

--- a/lib/dor/services/client/object.rb
+++ b/lib/dor/services/client/object.rb
@@ -103,19 +103,6 @@ module Dor
           raise_exception_based_on_response!(resp)
         end
 
-        # TODO: Remove once Argo is using `VirtualObjects#create` instead.
-        # Does a virtual-merge of the children into the parent
-        # @param [Array<String>] child_druids the identifier of the children
-        # @raise [NotFoundResponse] when the response is a 404 (object not found)
-        # @raise [UnexpectedResponse] when the response is not successful.
-        # @return [boolean] true on success
-        def add_constituents(child_druids:)
-          resp =  connection.put object_path, constituent_ids: child_druids
-          return true if resp.success?
-
-          raise_exception_based_on_response!(resp)
-        end
-
         # Notify the external Goobi system for a new object that was registered in DOR
         # @raise [NotFoundResponse] when the response is a 404 (object not found)
         # @raise [UnexpectedResponse] when the response is not successful.

--- a/spec/dor/services/client/object_spec.rb
+++ b/spec/dor/services/client/object_spec.rb
@@ -202,42 +202,6 @@ RSpec.describe Dor::Services::Client::Object do
     end
   end
 
-  describe '#add_constituents' do
-    subject(:request) { client.add_constituents(child_druids: ['druid:child1', 'druid:child2']) }
-
-    before do
-      stub_request(:put, 'https://dor-services.example.com/v1/objects/druid:1234')
-        .with(body: { constituent_ids: ['druid:child1', 'druid:child2'] })
-        .to_return(status: status)
-    end
-
-    context 'when API request succeeds' do
-      let(:status) { 200 }
-
-      it 'returns true' do
-        expect(request).to be true
-      end
-    end
-
-    context 'when API request returns 404' do
-      let(:status) { [404, 'not found'] }
-
-      it 'raises a NotFoundResponse exception' do
-        expect { request }.to raise_error(Dor::Services::Client::NotFoundResponse,
-                                          "not found: 404 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY})")
-      end
-    end
-
-    context 'when API request fails' do
-      let(:status) { [401, 'unauthorized'] }
-
-      it 'raises an error' do
-        expect { request }.to raise_error(Dor::Services::Client::UnexpectedResponse,
-                                          "unauthorized: 401 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY})")
-      end
-    end
-  end
-
   describe '#notify_goobi' do
     subject(:request) { client.notify_goobi }
 


### PR DESCRIPTION
Now that Argo uses the `Dor::Services::Client.virtual_objects` method, instead of `.objects.add_constituents`, no code hits this anymore and can be removed.