### PR TITLE
Use new virtual object creation endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ virtual_objects_client = Dor::Services::Client.virtual_objects
 # Create a batch of virtual objects
 virtual_objects_client.create(virtual_objects: [{ parent_id: '', child_ids: [''] }])
 
+# For getting background job results
+background_jobs_client = Dor::Services::Client.background_job_results
+
+# Show results of background job
+background_jobs_client.show(job_id: 123)
+
 # For performing operations on a known, registered object
 object_client = Dor::Services::Client.object(object_identifier)
 

--- a/lib/dor/services/client.rb
+++ b/lib/dor/services/client.rb
@@ -76,6 +76,11 @@ module Dor
         @virtual_objects ||= VirtualObjects.new(connection: connection, version: DEFAULT_VERSION)
       end
 
+      # @return [Dor::Services::Client::BackgroundJobResults] an instance of the `Client::BackgroundJobResults` class
+      def background_job_results
+        @background_job_results ||= BackgroundJobResults.new(connection: connection, version: DEFAULT_VERSION)
+      end
+
       class << self
         # @param [String] url
         # @param [String] token a bearer token for HTTP authentication
@@ -99,7 +104,7 @@ module Dor
           self
         end
 
-        delegate :objects, :object, :virtual_objects, to: :instance
+        delegate :objects, :object, :virtual_objects, :background_job_results, to: :instance
       end
 
       attr_writer :url, :token, :connection

--- a/lib/dor/services/client/background_job_results.rb
+++ b/lib/dor/services/client/background_job_results.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module Dor
+  module Services
+    class Client
+      # API calls around background job results from dor-services-app
+      class BackgroundJobResults < VersionedService
+        # Get status/result of a background job
+        # @param job_id [String] required string representing a job identifier
+        # @raise [NotFoundResponse] when the response is a 404 (object not found)
+        # @raise [UnexpectedResponse] on an unsuccessful response from the server
+        # @return [String] result of background job
+        def show(job_id:)
+          resp = connection.get do |req|
+            req.url "#{api_version}/background_job_results/#{job_id}"
+            req.headers['Accept'] = 'application/json'
+          end
+          # We expect this endpoint to semi-regularly return 422 responses, so do
+          # not bother raising the exception
+          return JSON.parse(resp.body).with_indifferent_access if resp.success? || resp.status == 422
+
+          raise_exception_based_on_response!(resp)
+        end
+
+        private
+
+        def raise_exception_based_on_response!(response)
+          raise (response.status == 404 ? NotFoundResponse : UnexpectedResponse),
+                ResponseErrorFormatter.format(response: response)
+        end
+      end
+    end
+  end
+end

--- a/lib/dor/services/client/virtual_objects.rb
+++ b/lib/dor/services/client/virtual_objects.rb
@@ -9,7 +9,7 @@ module Dor
         # @param virtual_objects [Array] required array of virtual object params (see dor-services-app)
         # @raise [NotFoundResponse] when the response is a 404 (object not found)
         # @raise [UnexpectedResponse] on an unsuccessful response from the server
-        # @return [NilClass] nil if no errors
+        # @return [String] URL from Location response header if no errors
         def create(virtual_objects:)
           resp = connection.post do |req|
             req.url "#{api_version}/virtual_objects"
@@ -17,7 +17,7 @@ module Dor
             req.headers['Accept'] = 'application/json'
             req.body = { virtual_objects: virtual_objects }.to_json
           end
-          return if resp.success?
+          return resp.headers['Location'] if resp.success?
 
           raise_exception_based_on_response!(resp)
         end

--- a/spec/dor/services/client/background_job_results_spec.rb
+++ b/spec/dor/services/client/background_job_results_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+RSpec.describe Dor::Services::Client::BackgroundJobResults do
+  before do
+    Dor::Services::Client.configure(url: 'https://dor-services.example.com')
+  end
+
+  let(:connection) { Dor::Services::Client.instance.send(:connection) }
+
+  subject(:client) { described_class.new(connection: connection, version: 'v1') }
+
+  describe '#show' do
+    before do
+      stub_request(:get, 'https://dor-services.example.com/v1/background_job_results/123')
+        .with(
+          headers: { 'Accept' => 'application/json' }
+        )
+        .to_return(status: status, body: body)
+    end
+
+    context 'when API request returns 202' do
+      let(:status) { 202 }
+      let(:body) { '{"output":{},"status":"pending"}' }
+
+      it 'gets the status as a hash' do
+        result = client.show(job_id: 123)
+        expect(result[:output]).to eq({})
+        expect(result[:status]).to eq('pending')
+      end
+    end
+
+    context 'when API request returns 200' do
+      let(:status) { 200 }
+      let(:body) { '{"output":{},"status":"complete"}' }
+
+      it 'gets the status as a hash' do
+        result = client.show(job_id: 123)
+        expect(result[:output]).to eq({})
+        expect(result[:status]).to eq('complete')
+      end
+    end
+
+    context 'when API request returns 422' do
+      let(:status) { 422 }
+      let(:body) { '{"output":{"errors":["error one","error two"]},"status":"complete"}' }
+
+      it 'gets the status as a hash' do
+        result = client.show(job_id: 123)
+        expect(result[:output][:errors]).to eq(['error one', 'error two'])
+        expect(result[:status]).to eq('complete')
+      end
+    end
+
+    context 'when API request fails with 400' do
+      let(:status) { [400, 'bad request'] }
+      let(:body) { '{"errors":["error message here"]}' }
+
+      it 'raises an error' do
+        expect { client.show(job_id: 123) }.to raise_error(Dor::Services::Client::UnexpectedResponse,
+                                                           "bad request: 400 (#{body})")
+      end
+    end
+
+    context 'when API request fails with 404' do
+      let(:status) { [404, 'not found'] }
+      let(:body) { '{"errors":["error message here"]}' }
+
+      it 'raises an error' do
+        expect { client.show(job_id: 123) }.to raise_error(Dor::Services::Client::NotFoundResponse,
+                                                           "not found: 404 (#{body})")
+      end
+    end
+  end
+end

--- a/spec/dor/services/client/virtual_objects_spec.rb
+++ b/spec/dor/services/client/virtual_objects_spec.rb
@@ -33,25 +33,25 @@ RSpec.describe Dor::Services::Client::VirtualObjects do
           body: params,
           headers: { 'Content-Type' => 'application/json', 'Accept' => 'application/json' }
         )
-        .to_return(status: status, body: body)
+        .to_return(status: status, body: body, headers: { 'Location' => 'https://dor-services.example.com/v1/background_job_results/123' })
     end
 
     context 'when API request succeeds' do
-      let(:status) { 204 }
+      let(:status) { 201 }
       let(:body) { '' }
 
-      it 'posts params and returns nil' do
-        expect(client.create(virtual_objects: virtual_objects)).to be_nil
+      it 'posts params and returns a location header' do
+        expect(client.create(virtual_objects: virtual_objects)).to eq('https://dor-services.example.com/v1/background_job_results/123')
       end
     end
 
-    context 'when API request fails with 422' do
-      let(:status) { [422, 'unprocessable entity'] }
+    context 'when API request fails with 400' do
+      let(:status) { [400, 'bad request'] }
       let(:body) { '{"errors":["error message here"]}' }
 
       it 'raises an error' do
         expect { client.create(virtual_objects: virtual_objects) }.to raise_error(Dor::Services::Client::UnexpectedResponse,
-                                                                                  "unprocessable entity: 422 (#{body})")
+                                                                                  "bad request: 400 (#{body})")
       end
     end
   end

--- a/spec/dor/services/client_spec.rb
+++ b/spec/dor/services/client_spec.rb
@@ -53,6 +53,16 @@ RSpec.describe Dor::Services::Client do
         expect(described_class.virtual_objects).to eq described_class.virtual_objects
       end
     end
+
+    describe '.background_job_results' do
+      it 'returns an instance of Client::BackgroundJobResults' do
+        expect(described_class.background_job_results).to be_instance_of Dor::Services::Client::BackgroundJobResults
+      end
+
+      it 'returns the memoized instance when called again' do
+        expect(described_class.background_job_results).to eq described_class.background_job_results
+      end
+    end
   end
 
   describe '#configure' do


### PR DESCRIPTION
* Update `VirtualObjects` with new behavior: the virtual_objects endpoint in `dor-services-app` no longer returns 204 and 422; it now returns 400 and 201 with a location header
* Add background job results endpoint: this was recently added to `dor-services-app` to support more robust virtual object creation in Argo.