### PR TITLE
Bump to version 3.0.0

### DIFF
--- a/dor-services-client.gemspec
+++ b/dor-services-client.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport', '>= 4.2', '< 7'
   spec.add_dependency 'cocina-models', '~> 0.4.0'
-  spec.add_dependency 'deprecation'
   spec.add_dependency 'faraday', '~> 0.15'
   spec.add_dependency 'moab-versioning', '~> 4.0'
   spec.add_dependency 'nokogiri', '~> 1.8'

--- a/lib/dor/services/client/version.rb
+++ b/lib/dor/services/client/version.rb
@@ -3,7 +3,7 @@
 module Dor
   module Services
     class Client
-      VERSION = '2.6.2'
+      VERSION = '3.0.0'
     end
   end
 end

--- a/spec/dor/services/client/background_job_results_spec.rb
+++ b/spec/dor/services/client/background_job_results_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Dor::Services::Client::BackgroundJobResults do
   before do
-    Dor::Services::Client.configure(url: 'https://dor-services.example.com')
+    Dor::Services::Client.configure(url: 'https://dor-services.example.com', token: '123')
   end
 
   let(:connection) { Dor::Services::Client.instance.send(:connection) }

--- a/spec/dor/services/client/collections_spec.rb
+++ b/spec/dor/services/client/collections_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Dor::Services::Client::Collections do
   before do
-    Dor::Services::Client.configure(url: 'https://dor-services.example.com')
+    Dor::Services::Client.configure(url: 'https://dor-services.example.com', token: '123')
   end
 
   let(:connection) { Dor::Services::Client.instance.send(:connection) }

--- a/spec/dor/services/client/embargo_spec.rb
+++ b/spec/dor/services/client/embargo_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Dor::Services::Client::Embargo do
   before do
-    Dor::Services::Client.configure(url: 'https://dor-services.example.com')
+    Dor::Services::Client.configure(url: 'https://dor-services.example.com', token: '123')
   end
 
   let(:connection) { Dor::Services::Client.instance.send(:connection) }

--- a/spec/dor/services/client/files_spec.rb
+++ b/spec/dor/services/client/files_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Dor::Services::Client::Files do
   before do
-    Dor::Services::Client.configure(url: 'https://dor-services.example.com')
+    Dor::Services::Client.configure(url: 'https://dor-services.example.com', token: '123')
   end
 
   let(:connection) { Dor::Services::Client.instance.send(:connection) }

--- a/spec/dor/services/client/metadata_spec.rb
+++ b/spec/dor/services/client/metadata_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Dor::Services::Client::Metadata do
   before do
-    Dor::Services::Client.configure(url: 'https://dor-services.example.com')
+    Dor::Services::Client.configure(url: 'https://dor-services.example.com', token: '123')
   end
 
   let(:connection) { Dor::Services::Client.instance.send(:connection) }

--- a/spec/dor/services/client/object_spec.rb
+++ b/spec/dor/services/client/object_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Dor::Services::Client::Object do
   before do
-    Dor::Services::Client.configure(url: 'https://dor-services.example.com')
+    Dor::Services::Client.configure(url: 'https://dor-services.example.com', token: '123')
   end
 
   let(:connection) { Dor::Services::Client.instance.send(:connection) }

--- a/spec/dor/services/client/object_version_spec.rb
+++ b/spec/dor/services/client/object_version_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Dor::Services::Client::ObjectVersion do
   before do
-    Dor::Services::Client.configure(url: 'https://dor-services.example.com')
+    Dor::Services::Client.configure(url: 'https://dor-services.example.com', token: '123')
   end
 
   let(:connection) { Dor::Services::Client.instance.send(:connection) }

--- a/spec/dor/services/client/objects_spec.rb
+++ b/spec/dor/services/client/objects_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Dor::Services::Client::Objects do
   before do
-    Dor::Services::Client.configure(url: 'https://dor-services.example.com')
+    Dor::Services::Client.configure(url: 'https://dor-services.example.com', token: '123')
   end
 
   let(:connection) { Dor::Services::Client.instance.send(:connection) }

--- a/spec/dor/services/client/release_tags_spec.rb
+++ b/spec/dor/services/client/release_tags_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Dor::Services::Client::ReleaseTags do
   before do
-    Dor::Services::Client.configure(url: 'https://dor-services.example.com')
+    Dor::Services::Client.configure(url: 'https://dor-services.example.com', token: '123')
   end
 
   let(:connection) { Dor::Services::Client.instance.send(:connection) }

--- a/spec/dor/services/client/sdr_spec.rb
+++ b/spec/dor/services/client/sdr_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Dor::Services::Client::SDR do
   before do
-    Dor::Services::Client.configure(url: 'https://dor-services.example.com')
+    Dor::Services::Client.configure(url: 'https://dor-services.example.com', token: '123')
   end
 
   let(:connection) { Dor::Services::Client.instance.send(:connection) }

--- a/spec/dor/services/client/virtual_objects_spec.rb
+++ b/spec/dor/services/client/virtual_objects_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Dor::Services::Client::VirtualObjects do
   before do
-    Dor::Services::Client.configure(url: 'https://dor-services.example.com')
+    Dor::Services::Client.configure(url: 'https://dor-services.example.com', token: '123')
   end
 
   let(:connection) { Dor::Services::Client.instance.send(:connection) }

--- a/spec/dor/services/client/workspace_spec.rb
+++ b/spec/dor/services/client/workspace_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Dor::Services::Client::Workspace do
   before do
-    Dor::Services::Client.configure(url: 'https://dor-services.example.com')
+    Dor::Services::Client.configure(url: 'https://dor-services.example.com', token: '123')
   end
 
   let(:connection) { Dor::Services::Client.instance.send(:connection) }

--- a/spec/dor/services/client_spec.rb
+++ b/spec/dor/services/client_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Dor::Services::Client do
 
   context 'once configured' do
     before do
-      described_class.configure(url: 'https://dor-services.example.com')
+      described_class.configure(url: 'https://dor-services.example.com', token: '123')
     end
 
     describe '.object' do
@@ -66,37 +66,13 @@ RSpec.describe Dor::Services::Client do
   end
 
   describe '#configure' do
-    subject(:client) { described_class.configure(url: 'https://dor-services.example.com') }
+    subject(:client) { described_class.configure(url: 'https://dor-services.example.com', token: '123') }
 
     it 'returns Client class' do
       expect(client).to eq Dor::Services::Client
     end
-  end
 
-  context 'when passed a token and token_header' do
-    before do
-      allow(Deprecation).to receive(:warn)
-      described_class.configure(url: 'https://dor-services.example.com',
-                                token_header: 'X-Auth',
-                                token: '123')
-    end
-
-    it 'ignores the supplied token header on the connection and issues a deprecation warning' do
-      expect(described_class.instance.send(:connection).headers).to include(
-        described_class::TOKEN_HEADER => 'Bearer 123',
-        'User-Agent' => /dor-services-client \d+\.\d+\.\d+/
-      )
-      expect(Deprecation).to have_received(:warn).once
-    end
-  end
-
-  context 'when passed a token' do
-    before do
-      described_class.configure(url: 'https://dor-services.example.com',
-                                token: '123')
-    end
-
-    it 'sets the token on the connection and uses the default authorization header' do
+    it 'sets the token on the connection using the default authorization header' do
       expect(described_class.instance.send(:connection).headers).to include(
         described_class::TOKEN_HEADER => 'Bearer 123',
         'User-Agent' => /dor-services-client \d+\.\d+\.\d+/


### PR DESCRIPTION
Version 3.0.0 includes:
* Token header no longer supported as an argument when configuring the client
* Token argument is now *required* when configuring the client
* Code slated for deprecation now removed
* Background job results endpoint added
* `VirtualObjects#create` returns URL string instead of `nil` when successful

Fixes #93