### PR TITLE
deprecate sdr.current_version in favor of preservation_client's current_version

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,6 @@ object_client.files.preserved_content(filename: filename_string, version: versio
 object_client.files.list
 object_client.release_tags.create(release: release, what: what, to: to, who: who)
 object_client.sdr.content_diff(current_content: existing_content)
-object_client.sdr.current_version
 object_client.sdr.metadata(datastream: dsid)
 object_client.sdr.signature_catalog
 

--- a/dor-services-client.gemspec
+++ b/dor-services-client.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport', '>= 4.2', '< 7'
   spec.add_dependency 'cocina-models', '~> 0.4.0'
+  spec.add_dependency 'deprecation'
   spec.add_dependency 'faraday', '~> 0.15'
   spec.add_dependency 'moab-versioning', '~> 4.0'
   spec.add_dependency 'nokogiri', '~> 1.8'

--- a/lib/dor/services/client.rb
+++ b/lib/dor/services/client.rb
@@ -3,6 +3,7 @@
 require 'active_support/core_ext/hash/indifferent_access'
 require 'active_support/core_ext/module/delegation'
 require 'active_support/core_ext/object/blank'
+require 'deprecation'
 require 'cocina/models'
 require 'faraday'
 require 'singleton'

--- a/lib/dor/services/client/sdr.rb
+++ b/lib/dor/services/client/sdr.rb
@@ -8,6 +8,9 @@ module Dor
     class Client
       # API calls that are about preserved objects
       class SDR < VersionedService
+        extend Deprecation
+        self.deprecation_horizon = 'dor-services-client version 4.0'
+
         # @param object_identifier [String] the pid for the object
         def initialize(connection:, version:, object_identifier:)
           super(connection: connection, version: version)
@@ -29,6 +32,7 @@ module Dor
             raise MalformedResponse, "Unable to parse XML from current_version API call: #{xml}"
           end
         end
+        deprecation_deprecate current_version: 'use preservation-client current_version instead'
 
         def signature_catalog
           resp = signature_catalog_response

--- a/spec/dor/services/client/sdr_spec.rb
+++ b/spec/dor/services/client/sdr_spec.rb
@@ -168,6 +168,7 @@ RSpec.describe Dor::Services::Client::SDR do
     subject(:request) { client.current_version }
 
     before do
+      allow(Deprecation).to receive(:warn)
       stub_request(:get, 'https://dor-services.example.com/v1/sdr/objects/druid:1234/current_version')
         .to_return(status: status, body: body)
     end


### PR DESCRIPTION
## Why was this change made?

In order to get rid of sdr-services-app (which is a Sinatra app), we want to migrate that functionality to preservation_catalog.   The `current_version` functionality is already available;  there is already a preservation-client gem that should be used directly now, instead of dor-services-app (which was behaving as a proxy for sdr-services-app).

This PR deprecates the method that would make the API call to dor-services-app which would invoke sdr-services-app for current_version.

## Was the documentation updated?

in the README, yes.  Not sure where else.  Deprecating the client here before tackling the dor-services-app itself.
