### PR TITLE
Do not expect 422 responses from background job results endpoint

### DIFF
--- a/lib/dor/services/client/background_job_results.rb
+++ b/lib/dor/services/client/background_job_results.rb
@@ -17,9 +17,8 @@ module Dor
             req.url "#{api_version}/background_job_results/#{job_id}"
             req.headers['Accept'] = 'application/json'
           end
-          # We expect this endpoint to semi-regularly return 422 responses, so do
-          # not bother raising the exception
-          return JSON.parse(resp.body).with_indifferent_access if resp.success? || resp.status == 422
+
+          return JSON.parse(resp.body).with_indifferent_access if resp.success?
 
           raise_exception_based_on_response!(resp)
         end

--- a/spec/dor/services/client/background_job_results_spec.rb
+++ b/spec/dor/services/client/background_job_results_spec.rb
@@ -31,23 +31,25 @@ RSpec.describe Dor::Services::Client::BackgroundJobResults do
 
     context 'when API request returns 200' do
       let(:status) { 200 }
-      let(:body) { '{"output":{},"status":"complete"}' }
 
-      it 'gets the status as a hash' do
-        result = client.show(job_id: 123)
-        expect(result[:output]).to eq({})
-        expect(result[:status]).to eq('complete')
+      context 'without errors' do
+        let(:body) { '{"output":{},"status":"complete"}' }
+
+        it 'gets the status as a hash' do
+          result = client.show(job_id: 123)
+          expect(result[:output]).to eq({})
+          expect(result[:status]).to eq('complete')
+        end
       end
-    end
 
-    context 'when API request returns 422' do
-      let(:status) { 422 }
-      let(:body) { '{"output":{"errors":["error one","error two"]},"status":"complete"}' }
+      context 'with errors' do
+        let(:body) { '{"output":{"errors":["error one","error two"]},"status":"complete"}' }
 
-      it 'gets the status as a hash' do
-        result = client.show(job_id: 123)
-        expect(result[:output][:errors]).to eq(['error one', 'error two'])
-        expect(result[:status]).to eq('complete')
+        it 'gets the status as a hash' do
+          result = client.show(job_id: 123)
+          expect(result[:output][:errors]).to eq(['error one', 'error two'])
+          expect(result[:status]).to eq('complete')
+        end
       end
     end
 


### PR DESCRIPTION
Connects to sul-dlss/dor-services-app#447
Connects to sul-dlss/dor-services-app#336

Necessitated by changes made to sul-dlss/dor-services-app#450

## Why was this change made?


## Was the documentation (README, API, wiki, consul, etc.) updated?
