### PR TITLE
Add a reset workspace method

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,11 @@ object_client.sdr.content_diff(current_content: existing_content)
 object_client.sdr.metadata(datastream: dsid)
 object_client.sdr.signature_catalog
 
-# Create and remove workspaces
+# Create, remove, and reset workspaces
 object_client.workspace.create(source: object_path_string)
 object_client.workspace.cleanup
+object_client.workspace.reset
+
 
 # Update embargo
 object_client.embargo.update(embargo_date: date_string, requesting_user: username_string)

--- a/lib/dor/services/client/workspace.rb
+++ b/lib/dor/services/client/workspace.rb
@@ -33,6 +33,17 @@ module Dor
           raise UnexpectedResponse, ResponseErrorFormatter.format(response: resp) unless resp.success?
         end
 
+        # After an object has been copied to preservation the workspace can be
+        # reset. This is called by the reset-workspace step of the accessionWF
+        # @raise [UnexpectedResponse] if the request is unsuccessful.
+        # @return nil
+        def reset
+          resp = connection.post do |req|
+            req.url "#{workspace_path}/reset"
+          end
+          raise UnexpectedResponse, ResponseErrorFormatter.format(response: resp) unless resp.success?
+        end
+
         private
 
         def workspace_path

--- a/spec/dor/services/client/workspace_spec.rb
+++ b/spec/dor/services/client/workspace_spec.rb
@@ -63,4 +63,31 @@ RSpec.describe Dor::Services::Client::Workspace do
       end
     end
   end
+
+  describe '#reset' do
+    subject(:request) { client.reset }
+
+    context 'when API request succeeds' do
+      before do
+        stub_request(:post, 'https://dor-services.example.com/v1/objects/druid:123/workspace/reset')
+          .to_return(status: 200)
+      end
+
+      it 'raises no errors' do
+        expect(request).to be nil
+      end
+    end
+
+    context 'when API request fails' do
+      before do
+        stub_request(:post, 'https://dor-services.example.com/v1/objects/druid:123/workspace/reset')
+          .to_return(status: [500, 'something is amiss'])
+      end
+
+      it 'raises an error' do
+        expect { request }.to raise_error(Dor::Services::Client::UnexpectedResponse,
+                                          "something is amiss: 500 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY})")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made?
So that there's a way to use the client to do a workspace. Fixes #102 

## Was the documentation (README, API, wiki, consul, etc.) updated?

Yes
