### PR TITLE
Add a method to shelve objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,11 @@ background_jobs_client.show(job_id: 123)
 # For performing operations on a known, registered object
 object_client = Dor::Services::Client.object(object_identifier)
 
-# Publish an object
+# Publish an object (push to PURL)
 object_client.publish
+
+# Shelve an object (push to Stacks)
+object_client.shelve
 
 # Update the MARC record
 object_client.update_marc_record

--- a/lib/dor/services/client/object.rb
+++ b/lib/dor/services/client/object.rb
@@ -64,13 +64,26 @@ module Dor
           Collections.new(parent_params).collections
         end
 
-        # Publish a new object
+        # Publish an object (send to PURL)
         # @raise [NotFoundResponse] when the response is a 404 (object not found)
         # @raise [UnexpectedResponse] when the response is not successful.
         # @return [boolean] true on success
         def publish
           resp = connection.post do |req|
             req.url "#{object_path}/publish"
+          end
+          return true if resp.success?
+
+          raise_exception_based_on_response!(resp)
+        end
+
+        # Shelve an object (send to Stacks)
+        # @raise [NotFoundResponse] when the response is a 404 (object not found)
+        # @raise [UnexpectedResponse] when the response is not successful.
+        # @return [boolean] true on success
+        def shelve
+          resp = connection.post do |req|
+            req.url "#{object_path}/shelve"
           end
           return true if resp.success?
 

--- a/spec/dor/services/client/object_spec.rb
+++ b/spec/dor/services/client/object_spec.rb
@@ -133,6 +133,41 @@ RSpec.describe Dor::Services::Client::Object do
     end
   end
 
+  describe '#shelve' do
+    subject(:request) { client.shelve }
+
+    before do
+      stub_request(:post, 'https://dor-services.example.com/v1/objects/druid:1234/shelve')
+        .to_return(status: status)
+    end
+
+    context 'when API request succeeds' do
+      let(:status) { 204 }
+
+      it 'returns true' do
+        expect(request).to be true
+      end
+    end
+
+    context 'when API request returns 404' do
+      let(:status) { [404, 'not found'] }
+
+      it 'raises a NotFoundResponse exception' do
+        expect { request }.to raise_error(Dor::Services::Client::NotFoundResponse,
+                                          "not found: 404 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY})")
+      end
+    end
+
+    context 'when API request fails' do
+      let(:status) { [422, 'unprocessable entity'] }
+
+      it 'raises an error' do
+        expect { request }.to raise_error(Dor::Services::Client::UnexpectedResponse,
+                                          "unprocessable entity: 422 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY})")
+      end
+    end
+  end
+
   describe '#update_marc_record' do
     subject(:request) { client.update_marc_record }
 


### PR DESCRIPTION
## Why was this change made?
So that objects can be shelved using the client

## Was the documentation (README, API, wiki, consul, etc.) updated?
Yes