### PR TITLE
Upgrade cocina-models so that type is returned from #find

### DIFF
--- a/dor-services-client.gemspec
+++ b/dor-services-client.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport', '>= 4.2', '< 7'
-  spec.add_dependency 'cocina-models', '~> 0.4.0'
+  spec.add_dependency 'cocina-models', '~> 0.6.0'
   spec.add_dependency 'deprecation'
   spec.add_dependency 'faraday', '~> 0.15'
   spec.add_dependency 'moab-versioning', '~> 4.0'

--- a/lib/dor/services/client/collections.rb
+++ b/lib/dor/services/client/collections.rb
@@ -29,7 +29,7 @@ module Dor
         private
 
         def response_to_models(resp)
-          JSON.parse(resp.body)['collections'].map { |data| Cocina::Models::DRO.new(data.symbolize_keys) }
+          JSON.parse(resp.body)['collections'].map { |data| Cocina::Models.build(data) }
         end
 
         def object_path

--- a/lib/dor/services/client/object.rb
+++ b/lib/dor/services/client/object.rb
@@ -46,13 +46,13 @@ module Dor
         # Retrieves the Cocina model
         # @raise [NotFoundResponse] when the response is a 404 (object not found)
         # @raise [UnexpectedResponse] when the response is not successful.
-        # @return [Cocina::Models::DRO] the returned model
+        # @return [Cocina::Models::DRO,Cocina::Models::Collection,Cocina::Models::AdminPolicy] the returned model
         def find
           resp = connection.get do |req|
             req.url object_path
           end
 
-          return Cocina::Models::DRO.from_json(resp.body) if resp.success?
+          return Cocina::Models.build(JSON.parse(resp.body)) if resp.success?
 
           raise_exception_based_on_response!(resp)
         end

--- a/spec/dor/services/client/collections_spec.rb
+++ b/spec/dor/services/client/collections_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Dor::Services::Client::Collections do
           {
             "collections":[{
               "externalIdentifier":"druid:12343234",
-              "type":"collection",
+              "type":"http://cocina.sul.stanford.edu/models/collection.jsonld",
               "label":"my collection",
               "version":1
             }]

--- a/spec/dor/services/client/object_spec.rb
+++ b/spec/dor/services/client/object_spec.rb
@@ -72,16 +72,6 @@ RSpec.describe Dor::Services::Client::Object do
 
   describe '#find' do
     subject(:model) { client.find }
-    let(:json) do
-      <<~JSON
-        {
-          "externalIdentifier":"druid:12343234",
-          "type":"item",
-          "label":"my item",
-          "version":1
-        }
-      JSON
-    end
 
     before do
       stub_request(:get, 'https://dor-services.example.com/v1/objects/druid:1234')
@@ -89,7 +79,37 @@ RSpec.describe Dor::Services::Client::Object do
                    body: json)
     end
 
-    context 'when API request succeeds' do
+    context 'when API request succeeds with DRO' do
+      let(:json) do
+        <<~JSON
+          {
+            "externalIdentifier":"druid:12343234",
+            "type":"http://cocina.sul.stanford.edu/models/book.jsonld",
+            "label":"my item",
+            "version":1
+          }
+        JSON
+      end
+
+      let(:status) { 200 }
+
+      it 'returns the cocina model' do
+        expect(model.externalIdentifier).to eq 'druid:12343234'
+      end
+    end
+
+    context 'when API request succeeds with Collection' do
+      let(:json) do
+        <<~JSON
+          {
+            "externalIdentifier":"druid:12343234",
+            "type":"http://cocina.sul.stanford.edu/models/collection.jsonld",
+            "label":"my item",
+            "version":1
+          }
+        JSON
+      end
+
       let(:status) { 200 }
 
       it 'returns the cocina model' do


### PR DESCRIPTION
## Why was this change made?

So that common-accessioning can use the find endpoint to differentiate between types.


## Was the documentation (README, API, wiki, consul, etc.) updated?

Yes, the API docs were changed.