### PR TITLE
Add method for calling the preserve endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ object_client.publish
 # Shelve an object (push to Stacks)
 object_client.shelve
 
+# Preserve an object (push to SDR)
+object_client.preserve
+
 # Update the MARC record
 object_client.update_marc_record
 

--- a/lib/dor/services/client/object.rb
+++ b/lib/dor/services/client/object.rb
@@ -77,6 +77,19 @@ module Dor
           raise_exception_based_on_response!(resp)
         end
 
+        # Preserve an object (send to SDR)
+        # @raise [NotFoundResponse] when the response is a 404 (object not found)
+        # @raise [UnexpectedResponse] when the response is not successful.
+        # @return [String] URL from Location response header if no errors
+        def preserve
+          resp = connection.post do |req|
+            req.url "#{object_path}/preserve"
+          end
+          return resp.headers['Location'] if resp.success?
+
+          raise_exception_based_on_response!(resp)
+        end
+
         # Shelve an object (send to Stacks)
         # @raise [NotFoundResponse] when the response is a 404 (object not found)
         # @raise [UnexpectedResponse] when the response is not successful.

--- a/spec/dor/services/client/object_spec.rb
+++ b/spec/dor/services/client/object_spec.rb
@@ -153,6 +153,32 @@ RSpec.describe Dor::Services::Client::Object do
     end
   end
 
+  describe '#preserve' do
+    subject(:request) { client.preserve }
+
+    before do
+      stub_request(:post, 'https://dor-services.example.com/v1/objects/druid:1234/preserve')
+        .to_return(status: status, headers: { 'Location' => 'https://dor-services.example.com/v1/background_job_results/123' })
+    end
+
+    context 'when API request succeeds' do
+      let(:status) { 200 }
+
+      it 'returns true' do
+        expect(request).to eq 'https://dor-services.example.com/v1/background_job_results/123'
+      end
+    end
+
+    context 'when API request fails' do
+      let(:status) { [500, 'internal server error'] }
+
+      it 'raises an error' do
+        expect { request }.to raise_error(Dor::Services::Client::UnexpectedResponse,
+                                          "internal server error: 500 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY})")
+      end
+    end
+  end
+
   describe '#shelve' do
     subject(:request) { client.shelve }
 


### PR DESCRIPTION
## Why was this change made?
Add a new feature for calling the preserve endpoint
Fixes #109
Depends on https://github.com/sul-dlss/dor-services-app/pull/483

## Was the documentation (README, API, wiki, consul, etc.) updated?
Yes
