### PR TITLE
Deprecate signature catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,10 @@ object_client.files.retrieve(filename: filename_string)
 object_client.files.preserved_content(filename: filename_string, version: version_string)
 object_client.files.list
 object_client.release_tags.create(release: release, what: what, to: to, who: who)
+
+# Retrieve information from SDR
 object_client.sdr.content_diff(current_content: existing_content)
 object_client.sdr.metadata(datastream: dsid)
-object_client.sdr.signature_catalog
 
 # Create, remove, and reset workspaces
 object_client.workspace.create(source: object_path_string)

--- a/lib/dor/services/client/sdr.rb
+++ b/lib/dor/services/client/sdr.rb
@@ -42,6 +42,7 @@ module Dor
 
           Moab::SignatureCatalog.parse resp.body
         end
+        deprecation_deprecate :signature_catalog
 
         # Retrieves file difference manifest for contentMetadata from SDR
         #

--- a/spec/dor/services/client/sdr_spec.rb
+++ b/spec/dor/services/client/sdr_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Dor::Services::Client::SDR do
     subject(:request) { client.signature_catalog }
 
     before do
+      allow(Deprecation).to receive(:warn)
       stub_request(:get, 'https://dor-services.example.com/v1/sdr/objects/druid:1234/manifest/signatureCatalog.xml')
         .to_return(status: status, body: body)
     end


### PR DESCRIPTION
## Why was this change made?
This will no longer be used now that dor-services-app can transfer to preservation

## Was the documentation (README, API, wiki, consul, etc.) updated?

You know it!