### PR TITLE
Return the location of background jobs

### DIFF
--- a/lib/dor/services/client/object.rb
+++ b/lib/dor/services/client/object.rb
@@ -72,7 +72,7 @@ module Dor
           resp = connection.post do |req|
             req.url "#{object_path}/publish"
           end
-          return true if resp.success?
+          return resp.headers['Location'] if resp.success?
 
           raise_exception_based_on_response!(resp)
         end
@@ -98,7 +98,7 @@ module Dor
           resp = connection.post do |req|
             req.url "#{object_path}/shelve"
           end
-          return true if resp.success?
+          return resp.headers['Location'] if resp.success?
 
           raise_exception_based_on_response!(resp)
         end

--- a/spec/dor/services/client/object_spec.rb
+++ b/spec/dor/services/client/object_spec.rb
@@ -123,14 +123,14 @@ RSpec.describe Dor::Services::Client::Object do
 
     before do
       stub_request(:post, 'https://dor-services.example.com/v1/objects/druid:1234/publish')
-        .to_return(status: status)
+        .to_return(status: status, headers: { 'Location' => 'https://dor-services.example.com/v1/background_job_results/123' })
     end
 
     context 'when API request succeeds' do
       let(:status) { 200 }
 
       it 'returns true' do
-        expect(request).to be true
+        expect(request).to eq 'https://dor-services.example.com/v1/background_job_results/123'
       end
     end
 
@@ -184,14 +184,14 @@ RSpec.describe Dor::Services::Client::Object do
 
     before do
       stub_request(:post, 'https://dor-services.example.com/v1/objects/druid:1234/shelve')
-        .to_return(status: status)
+        .to_return(status: status, headers: { 'Location' => 'https://dor-services.example.com/v1/background_job_results/123' })
     end
 
     context 'when API request succeeds' do
       let(:status) { 204 }
 
       it 'returns true' do
-        expect(request).to be true
+        expect(request).to eq 'https://dor-services.example.com/v1/background_job_results/123'
       end
     end
 


### PR DESCRIPTION
## Why was this change made?

Both of these operations return meaningful location headers which the client was hiding.

## Was the documentation (README, API, wiki, consul, etc.) updated?

N/A
