### PR TITLE
Correct typo and clarify namespace in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,14 +127,14 @@ object_client.workspace.reset
 object_client.embargo.update(embargo_date: date_string, requesting_user: username_string)
 ```
 
-## Asynchonous results
+## Asynchronous results
 
 Some operations are asynchronous and they return a `Location` header that displays the
 result of the job.  These jobs can be monitored by using `AsyncResult`.
 
 ```
 background_result_url = virtual_objects_client.create(virtual_objects: [{ parent_id: '', child_ids: [''] }])
-result = AsyncResult.new(url: background_result_url)
+result = Dor::Services::Client::AsyncResult.new(url: background_result_url)
 
 # Checks the result one time
 result.complete?


### PR DESCRIPTION
## Why was this change made?

To correct a typo and clarify how to use `AsyncResult` in upstream codebases.

## Was the documentation (README, API, wiki, consul, etc.) updated?

Yes