### PR TITLE
Create common interface for handling async results

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,9 @@ object_client.embargo.update(embargo_date: date_string, requesting_user: usernam
 Some operations are asynchronous and they return a `Location` header that displays the
 result of the job.  These jobs can be monitored by using `AsyncResult`.
 
-```
+```ruby
 background_result_url = virtual_objects_client.create(virtual_objects: [{ parent_id: '', child_ids: [''] }])
-result = Dor::Services::Client::AsyncResult.new(url: background_result_url)
+result = virtual_objects_client.async_result(url: background_result_url)
 
 # Checks the result one time
 result.complete?

--- a/lib/dor/services/client/async_result.rb
+++ b/lib/dor/services/client/async_result.rb
@@ -7,6 +7,8 @@ module Dor
     class Client
       # A helper for monitoring asynchonous jobs
       class AsyncResult
+        attr_reader :url
+
         # @param [String] url the url of the background result
         def initialize(url:)
           @url = url
@@ -29,8 +31,6 @@ module Dor
         def errors
           @results[:output][:errors]
         end
-
-        attr_reader :url, :seconds_between_requests, :timeout_in_seconds
 
         private
 

--- a/lib/dor/services/client/versioned_service.rb
+++ b/lib/dor/services/client/versioned_service.rb
@@ -10,6 +10,11 @@ module Dor
           @api_version = version
         end
 
+        # Common interface for handling asynchronous results
+        def async_result(url:)
+          AsyncResult.new(url: url)
+        end
+
         private
 
         attr_reader :connection, :api_version

--- a/spec/dor/services/client/versioned_service_spec.rb
+++ b/spec/dor/services/client/versioned_service_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe Dor::Services::Client::VersionedService do
+  before do
+    Dor::Services::Client.configure(url: 'https://dor-services.example.com', token: '123')
+  end
+
+  let(:subclass) do
+    Class.new(described_class)
+  end
+  let(:connection) { Dor::Services::Client.instance.send(:connection) }
+
+  subject(:client) { subclass.new(connection: connection, version: 'v1') }
+
+  describe '#async_result' do
+    it 'creates an instance of AsyncResult' do
+      expect(client.async_result(url: 'foobar')).to be_a(Dor::Services::Client::AsyncResult)
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

This allows all subclasses of `VersionedService` to respond to `#async_result`, exposing less of `Dor::Services::Client` internals to downstream code.

Also, remove unused `attr_reader` attributes in `AsyncResult`.

## Was the documentation (README, API, wiki, consul, etc.) updated?

Yes.