### PR TITLE
Do not default the workflow when calling publish

### DIFF
--- a/lib/dor/services/client/embargo.rb
+++ b/lib/dor/services/client/embargo.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: tru
+# frozen_string_literal: true
 
 module Dor
   module Services

--- a/lib/dor/services/client/metadata.rb
+++ b/lib/dor/services/client/metadata.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: tru
+# frozen_string_literal: true
 
 module Dor
   module Services

--- a/lib/dor/services/client/object.rb
+++ b/lib/dor/services/client/object.rb
@@ -70,12 +70,10 @@ module Dor
         # @param [String] workflow ('accessionWF') which workflow to callback to.
         # @return [boolean] true on success
         def publish(workflow: nil)
-          unless workflow
-            workflow = 'accessionWF'
-            Deprecation.warn(self, 'calling publish without passing a workflow is deprecated and will be removed in the next major version')
-          end
+          publish_path = "#{object_path}/publish"
+          publish_path = "#{publish_path}?workflow=#{workflow}" if workflow
           resp = connection.post do |req|
-            req.url "#{object_path}/publish?workflow=#{workflow}"
+            req.url publish_path
           end
           return resp.headers['Location'] if resp.success?
 

--- a/spec/dor/services/client/object_spec.rb
+++ b/spec/dor/services/client/object_spec.rb
@@ -120,9 +120,12 @@ RSpec.describe Dor::Services::Client::Object do
 
   describe '#publish' do
     subject(:request) { client.publish(workflow: 'accessionWF') }
+    subject(:no_wf_request) { client.publish }
 
     before do
       stub_request(:post, 'https://dor-services.example.com/v1/objects/druid:1234/publish?workflow=accessionWF')
+        .to_return(status: status, headers: { 'Location' => 'https://dor-services.example.com/v1/background_job_results/123' })
+      stub_request(:post, 'https://dor-services.example.com/v1/objects/druid:1234/publish')
         .to_return(status: status, headers: { 'Location' => 'https://dor-services.example.com/v1/background_job_results/123' })
     end
 
@@ -131,6 +134,10 @@ RSpec.describe Dor::Services::Client::Object do
 
       it 'returns true' do
         expect(request).to eq 'https://dor-services.example.com/v1/background_job_results/123'
+      end
+
+      it 'returns true' do
+        expect(no_wf_request).to eq 'https://dor-services.example.com/v1/background_job_results/123'
       end
     end
 
@@ -141,6 +148,11 @@ RSpec.describe Dor::Services::Client::Object do
         expect { request }.to raise_error(Dor::Services::Client::NotFoundResponse,
                                           "not found: 404 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY})")
       end
+
+      it 'raises a NotFoundResponse exception' do
+        expect { no_wf_request }.to raise_error(Dor::Services::Client::NotFoundResponse,
+                                                "not found: 404 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY})")
+      end
     end
 
     context 'when API request fails' do
@@ -149,6 +161,11 @@ RSpec.describe Dor::Services::Client::Object do
       it 'raises an error' do
         expect { request }.to raise_error(Dor::Services::Client::UnexpectedResponse,
                                           "conflict: 409 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY})")
+      end
+
+      it 'raises an error' do
+        expect { no_wf_request }.to raise_error(Dor::Services::Client::UnexpectedResponse,
+                                                "conflict: 409 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY})")
       end
     end
   end

--- a/spec/dor/services/client/object_spec.rb
+++ b/spec/dor/services/client/object_spec.rb
@@ -162,11 +162,6 @@ RSpec.describe Dor::Services::Client::Object do
         expect { request }.to raise_error(Dor::Services::Client::UnexpectedResponse,
                                           "conflict: 409 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY})")
       end
-
-      it 'raises an error' do
-        expect { no_wf_request }.to raise_error(Dor::Services::Client::UnexpectedResponse,
-                                                "conflict: 409 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY})")
-      end
     end
   end
 


### PR DESCRIPTION
## Why was this change made?

Argo calls publish without a workflow step, this has introduced workflow steps into objects (i.e.: https://argo.stanford.edu/view/druid:ts561xq4138) when not going through workflow. 

## Was the documentation (README, API, wiki, consul, etc.) updated?

N/A