### PR TITLE
Add a method for updating legacy metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,14 @@ object_client.metadata.dublin_core
 # Get the public descriptive XML representation
 object_client.metadata.descriptive
 
+# Update legacy XML representation
+object_client.metadata.legacy_update(
+  descriptive: {
+    updated: Time.now,
+    content: '<descMetadata/>'
+  }
+)
+
 # Return the Cocina metadata
 object_client.find
 


### PR DESCRIPTION
## Why was this change made?

So that the Legacy metadata api on dor-services-app can be used.

## Was the documentation (README, API, wiki, consul, etc.) updated?

yes.