### PR TITLE
deprecate sdr.content_diff in favor of preservation-client.content_inventory_diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,6 @@ object_client.files.list
 object_client.release_tags.create(release: release, what: what, to: to, who: who)
 
 # Retrieve information from SDR
-object_client.sdr.content_diff(current_content: existing_content)
 object_client.sdr.metadata(datastream: dsid)
 
 # Create, remove, and reset workspaces

--- a/lib/dor/services/client/sdr.rb
+++ b/lib/dor/services/client/sdr.rb
@@ -42,7 +42,7 @@ module Dor
 
           Moab::SignatureCatalog.parse resp.body
         end
-        deprecation_deprecate :signature_catalog
+        deprecation_deprecate signature_catalog: 'use preservation-client signature_catalog instead'
 
         # Retrieves file difference manifest for contentMetadata from SDR
         #
@@ -57,6 +57,7 @@ module Dor
 
           Moab::FileInventoryDifference.parse(resp)
         end
+        deprecation_deprecate content_diff: 'use preservation-client content_inventory_diff instead'
 
         # @param [String] datastream The identifier of the metadata datastream
         # @return [String, NilClass] datastream content from previous version of the object (from SDR storage), or nil if response status is 404

--- a/spec/dor/services/client/sdr_spec.rb
+++ b/spec/dor/services/client/sdr_spec.rb
@@ -105,6 +105,7 @@ RSpec.describe Dor::Services::Client::SDR do
     let(:status) { 200 }
 
     before do
+      allow(Deprecation).to receive(:warn)
       stub_request(:post, 'https://dor-services.example.com/v1/sdr/objects/druid:1234/cm-inv-diff?subset=all')
         .to_return(status: status, body: body)
     end


### PR DESCRIPTION
- ~~should not be deployed until sul-dlss/preservation_catalog/pull/1250 is deployed~~
- ~~should not be deployed until sul-dlss/common-accessioning/pull/465 is deployed~~
- ~~should not be deployed until sul-dlss/dor-services-app/pull/514 is deployed~~

## Why was this change made?

To get rid of `cm-inv-diff` API endpoint in sdr-services-app. We use preservation-client methods directly in the callers instead.

## Was the documentation (README, API, wiki, consul, etc.) updated?

yes