### PR TITLE
deprecate sdr.metadata, files.preserved_content 

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,6 @@ object_client.find
 object_client.collections
 
 object_client.files.retrieve(filename: filename_string)
-object_client.files.preserved_content(filename: filename_string, version: version_string)
 object_client.files.list
 object_client.release_tags.create(release: release, what: what, to: to, who: who)
 

--- a/README.md
+++ b/README.md
@@ -120,9 +120,6 @@ object_client.files.retrieve(filename: filename_string)
 object_client.files.list
 object_client.release_tags.create(release: release, what: what, to: to, who: who)
 
-# Retrieve information from SDR
-object_client.sdr.metadata(datastream: dsid)
-
 # Create, remove, and reset workspaces
 object_client.workspace.create(source: object_path_string)
 object_client.workspace.cleanup

--- a/lib/dor/services/client/files.rb
+++ b/lib/dor/services/client/files.rb
@@ -5,6 +5,9 @@ module Dor
     class Client
       # API calls relating to files
       class Files < VersionedService
+        extend Deprecation
+        self.deprecation_horizon = 'dor-services-client version 4.0'
+
         # @param object_identifier [String] the pid for the object
         def initialize(connection:, version:, object_identifier:)
           super(connection: connection, version: version)
@@ -35,6 +38,7 @@ module Dor
 
           resp.body
         end
+        deprecation_deprecate preserved_content: 'use preservation-client .content instead'
 
         # Get the list of files in the workspace
         # @return [Array<String>] the list of filenames in the workspace

--- a/lib/dor/services/client/sdr.rb
+++ b/lib/dor/services/client/sdr.rb
@@ -6,6 +6,7 @@ require 'moab'
 module Dor
   module Services
     class Client
+      # Deprecated; remove in release 4.0
       # API calls that are about preserved objects
       class SDR < VersionedService
         extend Deprecation
@@ -32,7 +33,7 @@ module Dor
             raise MalformedResponse, "Unable to parse XML from current_version API call: #{xml}"
           end
         end
-        deprecation_deprecate current_version: 'use preservation-client current_version instead'
+        deprecation_deprecate current_version: 'use preservation-client .current_version instead'
 
         def signature_catalog
           resp = signature_catalog_response
@@ -42,7 +43,7 @@ module Dor
 
           Moab::SignatureCatalog.parse resp.body
         end
-        deprecation_deprecate signature_catalog: 'use preservation-client signature_catalog instead'
+        deprecation_deprecate signature_catalog: 'use preservation-client .signature_catalog instead'
 
         # Retrieves file difference manifest for contentMetadata from SDR
         #
@@ -57,7 +58,7 @@ module Dor
 
           Moab::FileInventoryDifference.parse(resp)
         end
-        deprecation_deprecate content_diff: 'use preservation-client content_inventory_diff instead'
+        deprecation_deprecate content_diff: 'use preservation-client .content_inventory_diff instead'
 
         # @param [String] datastream The identifier of the metadata datastream
         # @return [String, NilClass] datastream content from previous version of the object (from SDR storage), or nil if response status is 404
@@ -71,6 +72,7 @@ module Dor
 
           raise UnexpectedResponse, ResponseErrorFormatter.format(response: resp, object_identifier: object_identifier)
         end
+        deprecation_deprecate metadata: 'use preservation-client .metadata instead'
 
         private
 

--- a/spec/dor/services/client/files_spec.rb
+++ b/spec/dor/services/client/files_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe Dor::Services::Client::Files do
   describe '#preserved_content' do
     subject { client.preserved_content(filename: 'olemiss1v.jp2', version: 1) }
     before do
+      # allow(Deprecation).to receive(:warn) # it's probably better for this warning to display
       stub_request(:get, 'https://dor-services.example.com/v1/sdr/objects/druid:ck546xs5106/content/olemiss1v.jp2?version=1')
         .to_return(status: status, body: body)
     end


### PR DESCRIPTION
- ~~should not be merged before https://github.com/sul-dlss/argo/pull/1741.~~
- need to release new gem after this is merged ~~and https://github.com/sul-dlss/argo/pull/1741 is deployed~~

## Why was this change made?

To get rid of `content` and `metadata` API endpoints in sdr-services-app. We use preservation-client `content` or `metadata` methods directly in the callers instead, going directly to preservation-catalog API.  (No need to go through dor-services-app).

- consumer(s) of `files.preserved_content`:
  - the only consumer of `content` is Argo, per https://github.com/search?q=preserved_content+org%3Asul-dlss&type=Code and PR mentioned above.
  - was here:  https://github.com/sul-dlss/argo/blob/master/app/controllers/files_controller.rb#L28
  - PR sul-dlss/argo#1741
- consumer(s) of `sdr.metadata`
  - the only consumer was here: https://github.com/sul-dlss/common-accessioning/blob/master/lib/technical_metadata_service.rb#L105
  - PR sul-dlss/common-accessioning/pull/465, deployed with Monday updates on 12/9
  - see https://github.com/search?q=org%3Asul-dlss+org%3Asul-dlss+extension%3Arb+%22sdr.metadata%22&unscoped_q=org%3Asul-dlss+extension%3Arb+%22sdr.metadata%22

## Was the documentation (README, API, wiki, consul, etc.) updated?

yes, README
