### PR TITLE
[WIP] Upgrade faraday to 1.0

### DIFF
--- a/dor-services-client.gemspec
+++ b/dor-services-client.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport', '>= 4.2', '< 7'
   spec.add_dependency 'cocina-models', '~> 0.6.0'
   spec.add_dependency 'deprecation'
-  spec.add_dependency 'faraday', '~> 0.15'
+  spec.add_dependency 'faraday', '~> 1.0'
   spec.add_dependency 'moab-versioning', '~> 4.0'
   spec.add_dependency 'nokogiri', '~> 1.8'
   spec.add_dependency 'zeitwerk', '~> 2.1'


### PR DESCRIPTION
## Why was this change made?
To support latest version of Faraday.

Blocked by https://github.com/lostisland/faraday_middleware/issues/199

## Was the documentation (README, API, wiki, consul, etc.) updated?
n/a