### PR TITLE
Add implemention of catkey endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,23 +51,29 @@ Note that the client may **not** be used without first having been configured, a
 Dor::Services:Client provides a number of methods to simplify connecting to the RESTful HTTP API of dor-services-app. In this section we list all of the available methods, reflecting how much of the API the client covers. For details see the [API docs](https://www.rubydoc.info/github/sul-dlss/dor-services-client/master/Dor/Services/Client)
 
 ```ruby
-# For performing operations on one or more objects
+# Perform operations on one or more objects
 objects_client = Dor::Services::Client.objects
 
-# For registering a non-existent object
+# Register a non-existent object
 objects_client.register(params: {})
 
-# For interacting with virtual objects
+# Interact with virtual objects
 virtual_objects_client = Dor::Services::Client.virtual_objects
 
 # Create a batch of virtual objects
 virtual_objects_client.create(virtual_objects: [{ parent_id: '', child_ids: [''] }])
 
-# For getting background job results
+# Retrieve background job results
 background_jobs_client = Dor::Services::Client.background_job_results
 
 # Show results of background job
 background_jobs_client.show(job_id: 123)
+
+# Perform MARCXML operations
+marcxml_client = Dor::Services::Client.marcxml
+
+# Retrieve a catkey for a given barcode
+marcxml_client.catkey(barcode: 'foobarcode')
 
 # For performing operations on a known, registered object
 object_client = Dor::Services::Client.object(object_identifier)

--- a/lib/dor/services/client.rb
+++ b/lib/dor/services/client.rb
@@ -66,6 +66,11 @@ module Dor
         @background_job_results ||= BackgroundJobResults.new(connection: connection, version: DEFAULT_VERSION)
       end
 
+      # @return [Dor::Services::Client::Marcxml] an instance of the `Client::Marcxml` class
+      def marcxml
+        @marcxml ||= Marcxml.new(connection: connection, version: DEFAULT_VERSION)
+      end
+
       class << self
         # @param [String] url the base url of the endpoint the client should connect to (required)
         # @param [String] token a bearer token for HTTP authentication (required)
@@ -79,7 +84,7 @@ module Dor
           self
         end
 
-        delegate :objects, :object, :virtual_objects, :background_job_results, to: :instance
+        delegate :background_job_results, :marcxml, :objects, :object, :virtual_objects, to: :instance
       end
 
       attr_writer :url, :token, :connection

--- a/lib/dor/services/client/background_job_results.rb
+++ b/lib/dor/services/client/background_job_results.rb
@@ -22,13 +22,6 @@ module Dor
 
           raise_exception_based_on_response!(resp)
         end
-
-        private
-
-        def raise_exception_based_on_response!(response)
-          raise (response.status == 404 ? NotFoundResponse : UnexpectedResponse),
-                ResponseErrorFormatter.format(response: response)
-        end
       end
     end
   end

--- a/lib/dor/services/client/marcxml.rb
+++ b/lib/dor/services/client/marcxml.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Dor
+  module Services
+    class Client
+      # API calls around MARCXML-based operations from dor-services-app
+      class Marcxml < VersionedService
+        # Get a catkey corresponding to a barcode
+        # @param barcode [String] required string representing a barcode
+        # @raise [NotFoundResponse] when the response is a 404 (object not found)
+        # @raise [UnexpectedResponse] on an unsuccessful response from the server
+        # @return [String] result of background job
+        def catkey(barcode:)
+          resp = connection.get do |req|
+            req.url "#{api_version}/catalog/catkey"
+            req.params['barcode'] = barcode
+          end
+
+          return resp.body if resp.success? && resp.body.present?
+          raise NotFoundResponse if resp.success? && resp.body.blank?
+
+          raise_exception_based_on_response!(resp)
+        end
+      end
+    end
+  end
+end

--- a/lib/dor/services/client/object.rb
+++ b/lib/dor/services/client/object.rb
@@ -150,11 +150,6 @@ module Dor
         def object_path
           "#{api_version}/objects/#{object_identifier}"
         end
-
-        def raise_exception_based_on_response!(response)
-          raise (response.status == 404 ? NotFoundResponse : UnexpectedResponse),
-                ResponseErrorFormatter.format(response: response)
-        end
       end
     end
   end

--- a/lib/dor/services/client/object_version.rb
+++ b/lib/dor/services/client/object_version.rb
@@ -85,11 +85,6 @@ module Dor
           "#{api_version}/objects/#{object_identifier}"
         end
 
-        def raise_exception_based_on_response!(response)
-          raise (response.status == 404 ? NotFoundResponse : UnexpectedResponse),
-                ResponseErrorFormatter.format(response: response)
-        end
-
         # Make request to server to open a new version
         # @param params [Hash] optional params (see dor-services-app)
         # @raise [NotFoundResponse] when the response is a 404 (object not found)

--- a/lib/dor/services/client/versioned_service.rb
+++ b/lib/dor/services/client/versioned_service.rb
@@ -18,6 +18,11 @@ module Dor
         private
 
         attr_reader :connection, :api_version
+
+        def raise_exception_based_on_response!(response)
+          raise (response.status == 404 ? NotFoundResponse : UnexpectedResponse),
+                ResponseErrorFormatter.format(response: response)
+        end
       end
     end
   end

--- a/lib/dor/services/client/virtual_objects.rb
+++ b/lib/dor/services/client/virtual_objects.rb
@@ -21,13 +21,6 @@ module Dor
 
           raise_exception_based_on_response!(resp)
         end
-
-        private
-
-        def raise_exception_based_on_response!(response)
-          raise (response.status == 404 ? NotFoundResponse : UnexpectedResponse),
-                ResponseErrorFormatter.format(response: response)
-        end
       end
     end
   end

--- a/spec/dor/services/client/marcxml_spec.rb
+++ b/spec/dor/services/client/marcxml_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+RSpec.describe Dor::Services::Client::Marcxml do
+  before do
+    Dor::Services::Client.configure(url: 'https://dor-services.example.com', token: '123')
+  end
+
+  let(:barcode) { 'abc123' }
+  let(:connection) { Dor::Services::Client.instance.send(:connection) }
+
+  subject(:client) { described_class.new(connection: connection, version: 'v1') }
+
+  describe '#catkey' do
+    before do
+      stub_request(:get, 'https://dor-services.example.com/v1/catalog/catkey')
+        .with(
+          query: { 'barcode' => barcode }
+        )
+        .to_return(status: status, body: body)
+    end
+
+    context 'when API request succeeds and there is a body' do
+      let(:status) { 200 }
+      let(:body) { 'catkey:abc123' }
+
+      it 'returns the catkey' do
+        expect(client.catkey(barcode: barcode)).to eq(body)
+      end
+    end
+
+    context 'when API request succeeds and there is no body (i.e., barcode is not found)' do
+      let(:status) { 200 }
+      let(:body) { '' }
+
+      it 'raises a NotFoundResponse error' do
+        expect { client.catkey(barcode: barcode) }.to raise_error(Dor::Services::Client::NotFoundResponse)
+      end
+    end
+
+    context 'when API request fails with 500' do
+      let(:status) { [500, 'internal server error'] }
+      let(:body) { '' }
+
+      it 'raises an error' do
+        expect { client.catkey(barcode: barcode) }.to raise_error(Dor::Services::Client::UnexpectedResponse,
+                                                                  /internal server error: 500 /)
+      end
+    end
+  end
+end

--- a/spec/dor/services/client_spec.rb
+++ b/spec/dor/services/client_spec.rb
@@ -34,6 +34,16 @@ RSpec.describe Dor::Services::Client do
       end
     end
 
+    describe '.marcxml' do
+      it 'returns an instance of Client::Marcxml' do
+        expect(described_class.marcxml).to be_instance_of Dor::Services::Client::Marcxml
+      end
+
+      it 'returns the memoized instance when called again' do
+        expect(described_class.marcxml).to eq described_class.marcxml
+      end
+    end
+
     describe '.objects' do
       it 'returns an instance of Client::Objects' do
         expect(described_class.objects).to be_instance_of Dor::Services::Client::Objects


### PR DESCRIPTION
Fixes #124

## Why was this change made?

This allows dor-services-client to hit the dor-services-app endpoint that resolves barcodes to catkeys. The endpoint has three separate behaviors:

1. Returns 500 when passed no barcode param or when barcode param is empty;
2. Returns 200 and a plain-text body when barcode param is passed and the lookup succeeds;
3. Returns 200 and an empty plain-text body when barcode param is passed and the lookup fails

This pull request accommodates these three cases, returning UnexpectedResponse for the first case, the catkey in the second case, and NotFoundResponse for the third case.

This pull request also pulls some copypasta code into a superclass.

## Was the documentation (README, API, wiki, consul, etc.) updated?

Yes, README.