### PR TITLE
Allow newest cocina-models version

### DIFF
--- a/dor-services-client.gemspec
+++ b/dor-services-client.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport', '>= 4.2', '< 7'
-  spec.add_dependency 'cocina-models', '~> 0.6.0'
+  spec.add_dependency 'cocina-models', '~> 0.8.0'
   spec.add_dependency 'faraday', '~> 0.15'
   spec.add_dependency 'moab-versioning', '~> 4.0'
   spec.add_dependency 'nokogiri', '~> 1.8'


### PR DESCRIPTION
Connects to sul-dlss/sdr-api#76

## Why was this change made?

To allow dor-services-client consumers to use the latest cocina-models release (0.8.0).

## Was the documentation (README, API, wiki, consul, etc.) updated?

no