### PR TITLE
Update cocina-models to 0.11.0

### DIFF
--- a/dor-services-client.gemspec
+++ b/dor-services-client.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport', '>= 4.2', '< 7'
-  spec.add_dependency 'cocina-models', '~> 0.8.0'
+  spec.add_dependency 'cocina-models', '~> 0.11.0'
   spec.add_dependency 'faraday', '~> 0.15'
   spec.add_dependency 'moab-versioning', '~> 4.0'
   spec.add_dependency 'nokogiri', '~> 1.8'


### PR DESCRIPTION
## Why was this change made?

So we can use the cocina-models to get admin policy object

## Was the documentation (README, API, wiki, consul, etc.) updated?
n/a