### PR TITLE
Handle provenance metadata through the legacy_update

### DIFF
--- a/lib/dor/services/client/metadata.rb
+++ b/lib/dor/services/client/metadata.rb
@@ -19,10 +19,11 @@ module Dor
         # @option opts [Hash] :rights Data for access rights metadata
         # @option opts [Hash] :content Data for structural metadata
         # @option opts [Hash] :technical Data for technical metadata
+        # @option opts [Hash] :provenance Data for provenance metadata
         # @example:
         #  legacy_update(descriptive: { updated: '2001-12-20', content: '<descMetadata />' })
         def legacy_update(opts)
-          opts = opts.slice(:descriptive, :rights, :content, :technical)
+          opts = opts.slice(:descriptive, :rights, :content, :technical, :provenance)
           resp = connection.patch do |req|
             req.url "#{base_path}/legacy"
             req.headers['Content-Type'] = 'application/json'

--- a/spec/dor/services/client/metadata_spec.rb
+++ b/spec/dor/services/client/metadata_spec.rb
@@ -79,33 +79,67 @@ RSpec.describe Dor::Services::Client::Metadata do
   end
 
   describe '#legacy_update' do
-    let(:params) { { descriptive: { updated: Time.find_zone('UTC').parse('2020-01-05'), content: '<descMetadata/>' } } }
+    context 'for descriptive' do
+      let(:params) { { descriptive: { updated: Time.find_zone('UTC').parse('2020-01-05'), content: '<descMetadata/>' } } }
 
-    before do
-      stub_request(:patch, 'https://dor-services.example.com/v1/objects/druid:1234/metadata/legacy')
-        .with(
-          body: '{"descriptive":{"updated":"2020-01-05T00:00:00.000Z","content":"\u003cdescMetadata/\u003e"}}',
-          headers: { 'Content-Type' => 'application/json' }
-        )
-        .to_return(status: status)
-    end
+      before do
+        stub_request(:patch, 'https://dor-services.example.com/v1/objects/druid:1234/metadata/legacy')
+          .with(
+            body: '{"descriptive":{"updated":"2020-01-05T00:00:00.000Z","content":"\u003cdescMetadata/\u003e"}}',
+            headers: { 'Content-Type' => 'application/json' }
+          )
+          .to_return(status: status)
+      end
 
-    context 'when API request succeeds' do
-      let(:status) { 204 }
+      context 'when API request succeeds' do
+        let(:status) { 204 }
 
-      it 'posts params as json' do
-        expect(client.legacy_update(params)).to be_nil
+        it 'posts params as json' do
+          expect(client.legacy_update(params)).to be_nil
+        end
+      end
+
+      context 'when API request fails' do
+        let(:status) { [404, 'not found'] }
+
+        it 'raises an error' do
+          expect { client.legacy_update(params) }.to(
+            raise_error(Dor::Services::Client::UnexpectedResponse,
+                        "not found: 404 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY}) for druid:1234")
+          )
+        end
       end
     end
 
-    context 'when API request fails' do
-      let(:status) { [404, 'not found'] }
+    context 'for provenance' do
+      let(:params) { { provenance: { updated: Time.find_zone('UTC').parse('2020-01-05'), content: '<provenanceMetadata />' } } }
 
-      it 'raises an error' do
-        expect { client.legacy_update(params) }.to(
-          raise_error(Dor::Services::Client::UnexpectedResponse,
-                      "not found: 404 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY}) for druid:1234")
-        )
+      before do
+        stub_request(:patch, 'https://dor-services.example.com/v1/objects/druid:1234/metadata/legacy')
+          .with(
+            body: '{"provenance":{"updated":"2020-01-05T00:00:00.000Z","content":"\\u003cprovenanceMetadata /\u003e"}}',
+            headers: { 'Content-Type' => 'application/json' }
+          )
+          .to_return(status: status)
+      end
+
+      context 'when API request succeeds' do
+        let(:status) { 204 }
+
+        it 'posts params as json' do
+          expect(client.legacy_update(params)).to be_nil
+        end
+      end
+
+      context 'when API request fails' do
+        let(:status) { [404, 'not found'] }
+
+        it 'raises an error' do
+          expect { client.legacy_update(params) }.to(
+            raise_error(Dor::Services::Client::UnexpectedResponse,
+                        "not found: 404 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY}) for druid:1234")
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
## Why was this change made?

Provenance content was being filtered out.


## Was the documentation (README, API, wiki, consul, etc.) updated?
n/a