### PR TITLE
Bump requirement on cocina-models to 0.13.0

### DIFF
--- a/dor-services-client.gemspec
+++ b/dor-services-client.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport', '>= 4.2', '< 7'
-  spec.add_dependency 'cocina-models', '~> 0.12.0'
+  spec.add_dependency 'cocina-models', '~> 0.13.0'
   spec.add_dependency 'faraday', '~> 0.15'
   spec.add_dependency 'moab-versioning', '~> 4.0'
   spec.add_dependency 'nokogiri', '~> 1.8'


### PR DESCRIPTION
## Why was this change made?

This allows Collections to return release tags.

## Was the documentation (README, API, wiki, consul, etc.) updated?
n/a