### PR TITLE
Make the event struct accept kwargs

### DIFF
--- a/lib/dor/services/client/events.rb
+++ b/lib/dor/services/client/events.rb
@@ -7,7 +7,7 @@ module Dor
     class Client
       # API calls that are about retrieving metadata
       class Events < VersionedService
-        Event = Struct.new(:event_type, :data)
+        Event = Struct.new(:event_type, :data, keyword_init: true)
 
         # @param object_identifier [String] the pid for the object
         def initialize(connection:, version:, object_identifier:)

--- a/spec/dor/services/client/events_spec.rb
+++ b/spec/dor/services/client/events_spec.rb
@@ -20,10 +20,14 @@ RSpec.describe Dor::Services::Client::Events do
 
     context 'when the object is found' do
       let(:status) { 200 }
-      let(:body) { '[{},{}]' }
+      let(:body) do
+        '[{"event_type":"shelve_request_received","data":{"host":"http://example.com/"}},' \
+      '{"event_type":"shelve_request_received","data":{"host":"http://example.com/"}}]'
+      end
 
       it 'returns the list' do
         expect(response.size).to eq 2
+        expect(response.first.event_type).to eq 'shelve_request_received'
       end
     end
 


### PR DESCRIPTION

## Why was this change made?
Previously we were using the struct as if it had this enabled, so all the data was going into the first argument (event_type).


## Was the documentation (README, API, wiki, consul, etc.) updated?
n/a