### PR TITLE
Remove nokogiri dependency

### DIFF
--- a/dor-services-client.gemspec
+++ b/dor-services-client.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'cocina-models', '~> 0.15.0'
   spec.add_dependency 'faraday', '~> 0.15'
   spec.add_dependency 'moab-versioning', '~> 4.0'
-  spec.add_dependency 'nokogiri', '~> 1.8'
   spec.add_dependency 'zeitwerk', '~> 2.1'
 
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
## Why was this change made?

Nothing needs it and nokogiri is a very heavy dependency.


## Was the documentation (README, API, wiki, consul, etc.) updated?
n/a