### PR TITLE
Add method for new dor-services-app endpoint displaying release tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,13 @@ object_client.find
 # Query for an objects collections
 object_client.collections
 
+# View information about an object's files
 object_client.files.retrieve(filename: filename_string)
 object_client.files.list
+
+# Set and list an object's release tags
 object_client.release_tags.create(release: release, what: what, to: to, who: who)
+object_client.release_tags.list
 
 # Get the events for the object
 object_client.events.list

--- a/lib/dor/services/client/release_tags.rb
+++ b/lib/dor/services/client/release_tags.rb
@@ -37,6 +37,19 @@ module Dor
         end
         # rubocop:enable Metrics/MethodLength
 
+        # List new release tags for the object
+        # @raise [UnexpectedResponse] if the request is unsuccessful.
+        # @return [Hash] (see Dor::ReleaseTags::IdentityMetadata.released_for)
+        def list
+          resp = connection.get do |req|
+            req.url "#{api_version}/objects/#{object_identifier}/release_tags"
+          end
+
+          return JSON.parse(resp.body) if resp.success?
+
+          raise_exception_based_on_response!(resp)
+        end
+
         private
 
         attr_reader :object_identifier


### PR DESCRIPTION
Connects to sul-dlss/google-books#283
Connects to sul-dlss/dor_indexing_app#336
Depends on sul-dlss/dor-services-app#656

## Why was this change made?

To support the work listed above.

## Was the documentation (README, API, wiki, consul, etc.) updated?

Yes.