### PR TITLE
Allow registration by passing in a cocina model

### DIFF
--- a/dor-services-client.gemspec
+++ b/dor-services-client.gemspec
@@ -23,7 +23,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport', '>= 4.2', '< 7'
-  spec.add_dependency 'cocina-models', '~> 0.15.0'
+  spec.add_dependency 'cocina-models', '~> 0.20.0'
+  spec.add_dependency 'deprecation', '~> 1.0'
   spec.add_dependency 'faraday', '~> 0.15'
   spec.add_dependency 'moab-versioning', '~> 4.0'
   spec.add_dependency 'zeitwerk', '~> 2.1'

--- a/lib/dor/services/client/objects.rb
+++ b/lib/dor/services/client/objects.rb
@@ -1,15 +1,27 @@
 # frozen_string_literal: true
 
+require 'deprecation'
+require 'active_support/json'
+require 'active_support/core_ext/object/json'
+
 module Dor
   module Services
     class Client
       # API calls that are about a repository objects
       class Objects < VersionedService
         # Creates a new object in DOR
+        # @param [Hash,Cocina::Models::RequestDRO,Cocina::Models::RequestCollection,Cocina::Models::RequestAPO] passing a hash is deprecated
         # @return [HashWithIndifferentAccess] the response, which includes a :pid
         def register(params:)
-          json = register_response(params: params)
-          JSON.parse(json).with_indifferent_access
+          if params.is_a? Hash
+            Deprecation.warn(self, 'passing a Hash to register is deprecated and will ' \
+              'be removed in dor-services-client 5.0. Use a Cocina::Models object instead.')
+          end
+          json_str = register_response(params: params)
+          json = JSON.parse(json_str)
+          return json.with_indifferent_access unless json.key?('type') # Legacy return
+
+          Cocina::Models.build(json)
         end
 
         private

--- a/spec/dor/services/client/collections_spec.rb
+++ b/spec/dor/services/client/collections_spec.rb
@@ -21,7 +21,12 @@ RSpec.describe Dor::Services::Client::Collections do
               "externalIdentifier":"druid:12343234",
               "type":"http://cocina.sul.stanford.edu/models/collection.jsonld",
               "label":"my collection",
-              "version":1
+              "version":1,
+              "description":{
+                "title": [
+                  { "titleFull": "hey!", "primary":true }
+                ]
+              }
             }]
           }
         JSON

--- a/spec/dor/services/client/object_spec.rb
+++ b/spec/dor/services/client/object_spec.rb
@@ -86,7 +86,12 @@ RSpec.describe Dor::Services::Client::Object do
             "externalIdentifier":"druid:12343234",
             "type":"http://cocina.sul.stanford.edu/models/book.jsonld",
             "label":"my item",
-            "version":1
+            "version":1,
+            "description":{
+              "title": [
+                { "titleFull": "hey!", "primary":true }
+              ]
+            }
           }
         JSON
       end
@@ -105,7 +110,12 @@ RSpec.describe Dor::Services::Client::Object do
             "externalIdentifier":"druid:12343234",
             "type":"http://cocina.sul.stanford.edu/models/collection.jsonld",
             "label":"my item",
-            "version":1
+            "version":1,
+            "description":{
+              "title": [
+                { "titleFull": "hey!", "primary":true }
+              ]
+            }
           }
         JSON
       end


### PR DESCRIPTION
## Why was this change made?

So we are able to validate the parameters that we allow users to pass to registration.

## Was the documentation (README, API, wiki, consul, etc.) updated?

n/a