### PR TITLE
Make the dependency on deprecation weaker

### DIFF
--- a/dor-services-client.gemspec
+++ b/dor-services-client.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport', '>= 4.2', '< 7'
   spec.add_dependency 'cocina-models', '~> 0.20.0'
-  spec.add_dependency 'deprecation', '~> 1.0'
+  spec.add_dependency 'deprecation', '>= 0'
   spec.add_dependency 'faraday', '~> 0.15'
   spec.add_dependency 'moab-versioning', '~> 4.0'
   spec.add_dependency 'zeitwerk', '~> 2.1'


### PR DESCRIPTION

## Why was this change made?

This allows this to be installed with active-fedora 8, which has an indirect dependency on
deprecation ~> 0.1

## Was the documentation (README, API, wiki, consul, etc.) updated?
n/a