### PR TITLE
Add a method to get a collections members

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,11 @@ object_client.metadata.legacy_update(
 # Return the Cocina metadata
 object_client.find
 
-# Query for an objects collections
+# Query for an object's collections
 object_client.collections
+
+# Query for a collection's members
+object_client.members
 
 # View information about an object's files
 object_client.files.retrieve(filename: filename_string)

--- a/lib/dor/services/client/members.rb
+++ b/lib/dor/services/client/members.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Dor
+  module Services
+    class Client
+      # API call that queries the members of a collection.
+      class Members < VersionedService
+        Member = Struct.new(:externalIdentifier, :type, keyword_init: true)
+
+        # @param object_identifier [String] the pid for the object
+        def initialize(connection:, version:, object_identifier:)
+          super(connection: connection, version: version)
+          @object_identifier = object_identifier
+        end
+
+        # Get a list of the members.
+        # @raise [UnexpectedResponse] if the request is unsuccessful.
+        # @return [Array<Member>]
+        def members
+          resp = connection.get do |req|
+            req.url members_path
+          end
+
+          return response_to_models(resp) if resp.success?
+
+          raise_exception_based_on_response!(resp, object_identifier)
+        end
+
+        private
+
+        def response_to_models(resp)
+          JSON.parse(resp.body)['members'].map { |result| Member.new(**result.symbolize_keys) }
+        end
+
+        def object_path
+          "#{api_version}/objects/#{object_identifier}"
+        end
+
+        def members_path
+          "#{object_path}/members"
+        end
+
+        attr_reader :object_identifier
+      end
+    end
+  end
+end

--- a/lib/dor/services/client/object.rb
+++ b/lib/dor/services/client/object.rb
@@ -64,6 +64,13 @@ module Dor
           Collections.new(parent_params).collections
         end
 
+        # Get a list of the members
+        # @raise [UnexpectedResponse] if the request is unsuccessful.
+        # @return [Array<Members::Member>]
+        def members
+          Members.new(parent_params).members
+        end
+
         # Publish an object (send to PURL)
         # @raise [NotFoundResponse] when the response is a 404 (object not found)
         # @raise [UnexpectedResponse] when the response is not successful.

--- a/spec/dor/services/client/members_spec.rb
+++ b/spec/dor/services/client/members_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+RSpec.describe Dor::Services::Client::Members do
+  before do
+    Dor::Services::Client.configure(url: 'https://dor-services.example.com', token: '123')
+  end
+
+  let(:connection) { Dor::Services::Client.instance.send(:connection) }
+  let(:pid) { 'druid:123' }
+
+  subject(:client) { described_class.new(connection: connection, version: 'v1', object_identifier: pid) }
+
+  describe '#members' do
+    subject(:members) { client.members }
+
+    context 'when API request succeeds' do
+      let(:json) do
+        <<~JSON
+          {
+            "members":[
+              {
+                "externalIdentifier":"druid:12343234",
+                "type":"collection"
+              },
+              {
+                "externalIdentifier":"druid:jg192kl9900",
+                "type":"item"
+              }
+            ]
+          }
+        JSON
+      end
+      before do
+        stub_request(:get, 'https://dor-services.example.com/v1/objects/druid:123/members')
+          .to_return(status: 200, body: json)
+      end
+
+      it 'returns members' do
+        expect(members.first.externalIdentifier).to eq 'druid:12343234'
+      end
+    end
+
+    context 'when API request fails' do
+      before do
+        stub_request(:get, 'https://dor-services.example.com/v1/objects/druid:123/members')
+          .to_return(status: [500, 'something is amiss'])
+      end
+
+      it 'raises an error' do
+        expect { members }.to raise_error(Dor::Services::Client::UnexpectedResponse,
+                                          "something is amiss: 500 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY}) for druid:123")
+      end
+    end
+  end
+end

--- a/spec/dor/services/client/object_spec.rb
+++ b/spec/dor/services/client/object_spec.rb
@@ -34,6 +34,18 @@ RSpec.describe Dor::Services::Client::Object do
     end
   end
 
+  describe '#members' do
+    let(:members) { instance_double(Dor::Services::Client::Members, members: true) }
+    before do
+      allow(Dor::Services::Client::Members).to receive(:new).and_return(members)
+    end
+
+    it 'delegates to the Client::Members' do
+      client.members
+      expect(members).to have_received(:members)
+    end
+  end
+
   describe '#release_tags' do
     it 'returns an instance of Client::ReleaseTags' do
       expect(client.release_tags).to be_instance_of Dor::Services::Client::ReleaseTags


### PR DESCRIPTION
## Why was this change made?

So we can use the method in dor-services-app rather than dor-fetcher.  Hopefully we can deprecate the latter service.
Fixes #145 

## Was the documentation (README, API, wiki, consul, etc.) updated?
yes
