### PR TITLE
Add support for admin tags endpoint

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
---format documentation
 --color
 --require spec_helper

--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ object_client.members
 object_client.files.retrieve(filename: filename_string)
 object_client.files.list
 
+# Create and list administrative tags for an object
+object_client.administrative_tags.create(tags: ['Tag : One', 'Tag : Two'])
+object_client.administrative_tags.list
+
 # Create and list release tags for an object
 object_client.release_tags.create(release: release, what: what, to: to, who: who)
 object_client.release_tags.list

--- a/lib/dor/services/client/administrative_tags.rb
+++ b/lib/dor/services/client/administrative_tags.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Dor
+  module Services
+    class Client
+      # Interact with administrative tags endpoint for a given object
+      class AdministrativeTags < VersionedService
+        # @param object_identifier [String] the pid for the object
+        def initialize(connection:, version:, object_identifier:)
+          super(connection: connection, version: version)
+          @object_identifier = object_identifier
+        end
+
+        # Creates one or more administrative tags for an object
+        # @param tags [Array<String>]
+        # @return [Boolean] true if successful
+        # @raise [NotFoundResponse] when the response is a 404 (object not found)
+        # @raise [UnexpectedResponse] if the request is unsuccessful.
+        def create(tags:)
+          resp = connection.post do |req|
+            req.url "#{api_version}/objects/#{object_identifier}/administrative_tags"
+            req.headers['Content-Type'] = 'application/json'
+            req.body = { administrative_tags: tags }.to_json
+          end
+          raise_exception_based_on_response!(resp, object_identifier) unless resp.success?
+
+          true
+        end
+
+        # List administrative tags for an object
+        # @raise [NotFoundResponse] when the response is a 404 (object not found)
+        # @raise [UnexpectedResponse] if the request is unsuccessful.
+        # @return [Hash]
+        def list
+          resp = connection.get do |req|
+            req.url "#{api_version}/objects/#{object_identifier}/administrative_tags"
+          end
+
+          raise_exception_based_on_response!(resp, object_identifier) unless resp.success?
+
+          JSON.parse(resp.body)
+        end
+
+        private
+
+        attr_reader :object_identifier
+      end
+    end
+  end
+end

--- a/lib/dor/services/client/object.rb
+++ b/lib/dor/services/client/object.rb
@@ -35,6 +35,10 @@ module Dor
           @release_tags ||= ReleaseTags.new(parent_params)
         end
 
+        def administrative_tags
+          @administrative_tags ||= AdministrativeTags.new(parent_params)
+        end
+
         def version
           @version ||= ObjectVersion.new(parent_params)
         end

--- a/spec/dor/services/client/administrative_tags_spec.rb
+++ b/spec/dor/services/client/administrative_tags_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+RSpec.describe Dor::Services::Client::AdministrativeTags do
+  before do
+    Dor::Services::Client.configure(url: 'https://dor-services.example.com', token: '123')
+  end
+
+  let(:connection) { Dor::Services::Client.instance.send(:connection) }
+  let(:druid) { 'druid:bc123df4567' }
+
+  subject(:client) { described_class.new(connection: connection, version: 'v1', object_identifier: druid) }
+
+  describe '#list' do
+    subject(:request) { client.list }
+
+    context 'when API request succeeds' do
+      before do
+        stub_request(:get, "https://dor-services.example.com/v1/objects/#{druid}/administrative_tags")
+          .to_return(status: 200, body: '["Registered By : mjgiarlo","Process : Content Type : Map"]')
+      end
+
+      it 'lists administrative tags' do
+        expect(request).to eq(['Registered By : mjgiarlo', 'Process : Content Type : Map'])
+      end
+    end
+
+    context 'when API request fails because of not found' do
+      before do
+        stub_request(:get, "https://dor-services.example.com/v1/objects/#{druid}/administrative_tags")
+          .to_return(status: [404, 'object not found'])
+      end
+
+      it 'raises an error' do
+        expect { request }.to raise_error(Dor::Services::Client::NotFoundResponse,
+                                          "object not found: 404 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY}) for #{druid}")
+      end
+    end
+
+    context 'when API request fails due to unexpected response' do
+      before do
+        stub_request(:get, "https://dor-services.example.com/v1/objects/#{druid}/administrative_tags")
+          .to_return(status: [500, 'something is amiss'])
+      end
+
+      it 'raises an error' do
+        expect { request }.to raise_error(Dor::Services::Client::UnexpectedResponse,
+                                          "something is amiss: 500 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY}) for #{druid}")
+      end
+    end
+  end
+
+  describe '#create' do
+    subject(:request) { client.create(tags: ['Registered By : mjgiarlo', 'Process : Content Type : Map']) }
+
+    context 'when API request succeeds' do
+      before do
+        stub_request(:post, "https://dor-services.example.com/v1/objects/#{druid}/administrative_tags")
+          .to_return(status: 201)
+      end
+
+      it 'posts tags' do
+        expect(request).to be true
+      end
+    end
+
+    context 'when API request fails' do
+      before do
+        stub_request(:post, "https://dor-services.example.com/v1/objects/#{druid}/administrative_tags")
+          .to_return(status: [500, 'something is amiss'])
+      end
+
+      it 'raises an error' do
+        expect { request }.to raise_error(Dor::Services::Client::UnexpectedResponse,
+                                          "something is amiss: 500 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY}) for #{druid}")
+      end
+    end
+  end
+end

--- a/spec/dor/services/client/object_spec.rb
+++ b/spec/dor/services/client/object_spec.rb
@@ -52,6 +52,12 @@ RSpec.describe Dor::Services::Client::Object do
     end
   end
 
+  describe '#administrative_tags' do
+    it 'returns an instance of Client::AdministrativeTags' do
+      expect(client.administrative_tags).to be_instance_of Dor::Services::Client::AdministrativeTags
+    end
+  end
+
   describe '#metadata' do
     it 'returns an instance of Client::Metadata' do
       expect(client.metadata).to be_instance_of Dor::Services::Client::Metadata


### PR DESCRIPTION
## Why was this change made?

To allow clients to use dor-services-client to interact with DSA's new admin tags endpoints.

## Was the documentation (README, API, wiki, consul, etc.) updated?

yes.