### PR TITLE
Allow use of Faraday 1.0

### DIFF
--- a/dor-services-client.gemspec
+++ b/dor-services-client.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport', '>= 4.2', '< 7'
   spec.add_dependency 'cocina-models', '~> 0.25.0'
   spec.add_dependency 'deprecation', '>= 0'
-  spec.add_dependency 'faraday', '~> 0.15'
+  spec.add_dependency 'faraday', '>= 0.15', '< 2'
   spec.add_dependency 'moab-versioning', '~> 4.0'
   spec.add_dependency 'zeitwerk', '~> 2.1'
 


### PR DESCRIPTION
## Why was this change made?

So that we can keep up to date with the latest fixes.

## Was the documentation (README, API, wiki, consul, etc.) updated?
n/a