### PR TITLE
Support update and destroy operations for administrative tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,11 @@ object_client.members
 object_client.files.retrieve(filename: filename_string)
 object_client.files.list
 
-# Create and list administrative tags for an object
+# Create, update, destroy, and list administrative tags for an object
 object_client.administrative_tags.create(tags: ['Tag : One', 'Tag : Two'])
+object_client.administrative_tags.replace(tags: ['Tag : One', 'Tag : Two']) # like #create but removes current tags first
+object_client.administrative_tags.update(current: 'Current : Tag', new: 'Replacement : Tag')
+object_client.administrative_tags.destroy(tag: 'Delete : Me')
 object_client.administrative_tags.list
 
 # Create and list release tags for an object

--- a/lib/dor/services/client/administrative_tags.rb
+++ b/lib/dor/services/client/administrative_tags.rb
@@ -12,6 +12,7 @@ module Dor
         end
 
         # Creates one or more administrative tags for an object
+        #
         # @param tags [Array<String>]
         # @return [Boolean] true if successful
         # @raise [NotFoundResponse] when the response is a 404 (object not found)
@@ -27,7 +28,25 @@ module Dor
           true
         end
 
+        # Replaces one or more administrative tags for an object
+        #
+        # @param tags [Array<String>]
+        # @return [Boolean] true if successful
+        # @raise [NotFoundResponse] when the response is a 404 (object not found)
+        # @raise [UnexpectedResponse] if the request is unsuccessful.
+        def replace(tags:)
+          resp = connection.post do |req|
+            req.url "#{api_version}/objects/#{object_identifier}/administrative_tags"
+            req.headers['Content-Type'] = 'application/json'
+            req.body = { administrative_tags: tags, replace: true }.to_json
+          end
+          raise_exception_based_on_response!(resp, object_identifier) unless resp.success?
+
+          true
+        end
+
         # List administrative tags for an object
+        #
         # @raise [NotFoundResponse] when the response is a 404 (object not found)
         # @raise [UnexpectedResponse] if the request is unsuccessful.
         # @return [Hash]
@@ -39,6 +58,39 @@ module Dor
           raise_exception_based_on_response!(resp, object_identifier) unless resp.success?
 
           JSON.parse(resp.body)
+        end
+
+        # Updates an administrative tag for an object
+        #
+        # @param current [String] current tag to update
+        # @param new [String] new tag to replace current tag
+        # @return [Boolean] true if successful
+        # @raise [NotFoundResponse] when the response is a 404 (object or current tag not found)
+        # @raise [UnexpectedResponse] if the request is unsuccessful.
+        def update(current:, new:)
+          resp = connection.put do |req|
+            req.url "#{api_version}/objects/#{object_identifier}/administrative_tags/#{CGI.escape(current)}"
+            req.headers['Content-Type'] = 'application/json'
+            req.body = { administrative_tag: new }.to_json
+          end
+          raise_exception_based_on_response!(resp, object_identifier) unless resp.success?
+
+          true
+        end
+
+        # Destroys an administrative tag for an object
+        #
+        # @param tag [String] a tag to destroy
+        # @return [Boolean] true if successful
+        # @raise [NotFoundResponse] when the response is a 404 (object or current tag not found)
+        # @raise [UnexpectedResponse] if the request is unsuccessful.
+        def destroy(tag:)
+          resp = connection.delete do |req|
+            req.url "#{api_version}/objects/#{object_identifier}/administrative_tags/#{CGI.escape(tag)}"
+          end
+          raise_exception_based_on_response!(resp, object_identifier) unless resp.success?
+
+          true
         end
 
         private

--- a/spec/dor/services/client/administrative_tags_spec.rb
+++ b/spec/dor/services/client/administrative_tags_spec.rb
@@ -63,9 +63,155 @@ RSpec.describe Dor::Services::Client::AdministrativeTags do
       end
     end
 
+    context 'when API request fails because of conflict' do
+      before do
+        stub_request(:post, "https://dor-services.example.com/v1/objects/#{druid}/administrative_tags")
+          .to_return(status: [409, 'conflict'])
+      end
+
+      it 'raises an error' do
+        expect { request }.to raise_error(Dor::Services::Client::UnexpectedResponse,
+                                          "conflict: 409 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY}) for #{druid}")
+      end
+    end
+
     context 'when API request fails' do
       before do
         stub_request(:post, "https://dor-services.example.com/v1/objects/#{druid}/administrative_tags")
+          .to_return(status: [500, 'something is amiss'])
+      end
+
+      it 'raises an error' do
+        expect { request }.to raise_error(Dor::Services::Client::UnexpectedResponse,
+                                          "something is amiss: 500 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY}) for #{druid}")
+      end
+    end
+  end
+
+  describe '#replace' do
+    subject(:request) { client.replace(tags: ['Registered By : mjgiarlo', 'Process : Content Type : Map']) }
+
+    context 'when API request succeeds' do
+      before do
+        stub_request(:post, "https://dor-services.example.com/v1/objects/#{druid}/administrative_tags")
+          .to_return(status: 201)
+      end
+
+      it 'replaces tags' do
+        expect(request).to be true
+      end
+    end
+
+    context 'when API request fails because of conflict' do
+      before do
+        stub_request(:post, "https://dor-services.example.com/v1/objects/#{druid}/administrative_tags")
+          .to_return(status: [409, 'conflict'])
+      end
+
+      it 'raises an error' do
+        expect { request }.to raise_error(Dor::Services::Client::UnexpectedResponse,
+                                          "conflict: 409 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY}) for #{druid}")
+      end
+    end
+
+    context 'when API request fails' do
+      before do
+        stub_request(:post, "https://dor-services.example.com/v1/objects/#{druid}/administrative_tags")
+          .to_return(status: [500, 'something is amiss'])
+      end
+
+      it 'raises an error' do
+        expect { request }.to raise_error(Dor::Services::Client::UnexpectedResponse,
+                                          "something is amiss: 500 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY}) for #{druid}")
+      end
+    end
+  end
+
+  describe '#update' do
+    subject(:request) { client.update(current: current_tag, new: new_tag) }
+
+    let(:current_tag) { 'Process : Content Type : Map' }
+    let(:new_tag) { 'Process : Content Type : Not A Map At All Actually' }
+
+    context 'when API request succeeds' do
+      before do
+        stub_request(:put, "https://dor-services.example.com/v1/objects/#{druid}/administrative_tags/#{CGI.escape(current_tag)}")
+          .to_return(status: 204)
+      end
+
+      it 'updates the administrative tag' do
+        expect(request).to be true
+      end
+    end
+
+    context 'when API request fails because of not found' do
+      before do
+        stub_request(:put, "https://dor-services.example.com/v1/objects/#{druid}/administrative_tags/#{CGI.escape(current_tag)}")
+          .to_return(status: [404, 'object not found'])
+      end
+
+      it 'raises an error' do
+        expect { request }.to raise_error(Dor::Services::Client::NotFoundResponse,
+                                          "object not found: 404 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY}) for #{druid}")
+      end
+    end
+
+    context 'when API request fails because of conflict' do
+      before do
+        stub_request(:put, "https://dor-services.example.com/v1/objects/#{druid}/administrative_tags/#{CGI.escape(current_tag)}")
+          .to_return(status: [409, 'conflict'])
+      end
+
+      it 'raises an error' do
+        expect { request }.to raise_error(Dor::Services::Client::UnexpectedResponse,
+                                          "conflict: 409 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY}) for #{druid}")
+      end
+    end
+
+    context 'when API request fails due to unexpected response' do
+      before do
+        stub_request(:put, "https://dor-services.example.com/v1/objects/#{druid}/administrative_tags/#{CGI.escape(current_tag)}")
+          .to_return(status: [500, 'something is amiss'])
+      end
+
+      it 'raises an error' do
+        expect { request }.to raise_error(Dor::Services::Client::UnexpectedResponse,
+                                          "something is amiss: 500 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY}) for #{druid}")
+      end
+    end
+  end
+
+  describe '#destroy' do
+    subject(:request) { client.destroy(tag: tag) }
+
+    let(:tag) { 'Process : Content Type : Map' }
+
+    context 'when API request succeeds' do
+      before do
+        stub_request(:delete, "https://dor-services.example.com/v1/objects/#{druid}/administrative_tags/#{CGI.escape(tag)}")
+          .to_return(status: 204)
+      end
+
+      it 'updates the administrative tag' do
+        expect(request).to be true
+      end
+    end
+
+    context 'when API request fails because of not found' do
+      before do
+        stub_request(:delete, "https://dor-services.example.com/v1/objects/#{druid}/administrative_tags/#{CGI.escape(tag)}")
+          .to_return(status: [404, 'object not found'])
+      end
+
+      it 'raises an error' do
+        expect { request }.to raise_error(Dor::Services::Client::NotFoundResponse,
+                                          "object not found: 404 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY}) for #{druid}")
+      end
+    end
+
+    context 'when API request fails due to unexpected response' do
+      before do
+        stub_request(:delete, "https://dor-services.example.com/v1/objects/#{druid}/administrative_tags/#{CGI.escape(tag)}")
           .to_return(status: [500, 'something is amiss'])
       end
 


### PR DESCRIPTION
Connects to sul-dlss/dor-services-app#679

Blocked by sul-dlss/dor-services-app#709

Tested in https://github.com/sul-dlss/infrastructure-integration-test/pull/34

Note that these methods won't be operational until https://github.com/sul-dlss/dor-services-app/pull/709 is merged.

## Why was this change made?

To support update and destroy operations for administrative tags, which is required by Argo.

## Was the documentation (README, API, wiki, consul, etc.) updated?

Yes.