### PR TITLE
Add identity to the datastreams that can be updated

### DIFF
--- a/lib/dor/services/client/metadata.rb
+++ b/lib/dor/services/client/metadata.rb
@@ -18,12 +18,13 @@ module Dor
         # @option opts [Hash] :descriptive Data for descriptive metadata
         # @option opts [Hash] :rights Data for access rights metadata
         # @option opts [Hash] :content Data for structural metadata
+        # @option opts [Hash] :identity Data for identity metadata
         # @option opts [Hash] :technical Data for technical metadata
         # @option opts [Hash] :provenance Data for provenance metadata
         # @example:
         #  legacy_update(descriptive: { updated: '2001-12-20', content: '<descMetadata />' })
         def legacy_update(opts)
-          opts = opts.slice(:descriptive, :rights, :content, :technical, :provenance)
+          opts = opts.slice(:descriptive, :rights, :identity, :content, :technical, :provenance)
           resp = connection.patch do |req|
             req.url "#{base_path}/legacy"
             req.headers['Content-Type'] = 'application/json'

--- a/spec/dor/services/client/metadata_spec.rb
+++ b/spec/dor/services/client/metadata_spec.rb
@@ -79,13 +79,19 @@ RSpec.describe Dor::Services::Client::Metadata do
   end
 
   describe '#legacy_update' do
-    context 'for descriptive' do
-      let(:params) { { descriptive: { updated: Time.find_zone('UTC').parse('2020-01-05'), content: '<descMetadata/>' } } }
+    context 'for many datastreams' do
+      let(:params) do
+        {
+          descriptive: { updated: Time.find_zone('UTC').parse('2020-01-05'), content: '<descMetadata/>' },
+          identity: { updated: Time.find_zone('UTC').parse('2020-01-05'), content: '<identityMetadata/>' }
+        }
+      end
 
       before do
         stub_request(:patch, 'https://dor-services.example.com/v1/objects/druid:1234/metadata/legacy')
           .with(
-            body: '{"descriptive":{"updated":"2020-01-05T00:00:00.000Z","content":"\u003cdescMetadata/\u003e"}}',
+            body: '{"descriptive":{"updated":"2020-01-05T00:00:00.000Z","content":"\\u003cdescMetadata/\\u003e"},' \
+                  '"identity":{"updated":"2020-01-05T00:00:00.000Z","content":"\\u003cidentityMetadata/\\u003e"}}',
             headers: { 'Content-Type' => 'application/json' }
           )
           .to_return(status: status)
@@ -95,6 +101,7 @@ RSpec.describe Dor::Services::Client::Metadata do
         let(:status) { 204 }
 
         it 'posts params as json' do
+          # byebug
           expect(client.legacy_update(params)).to be_nil
         end
       end


### PR DESCRIPTION
## Why was this change made?
Previously it was excluding identity.

## Was the documentation (README, API, wiki, consul, etc.) updated?
n/a