### PR TITLE
Return the content type from the admin tags endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ object_client.administrative_tags.replace(tags: ['Tag : One', 'Tag : Two']) # li
 object_client.administrative_tags.update(current: 'Current : Tag', new: 'Replacement : Tag')
 object_client.administrative_tags.destroy(tag: 'Delete : Me')
 object_client.administrative_tags.list
+object_client.administrative_tags.content_type
 
 # Create and list release tags for an object
 object_client.release_tags.create(release: release, what: what, to: to, who: who)

--- a/dor-services-client.gemspec
+++ b/dor-services-client.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport', '>= 4.2', '< 7'
-  spec.add_dependency 'cocina-models', '~> 0.29'
+  spec.add_dependency 'cocina-models', '~> 0.29.0' # leave pinned to patch level until cocina-models hits 1.0
   spec.add_dependency 'deprecation', '>= 0'
   spec.add_dependency 'faraday', '>= 0.15', '< 2'
   spec.add_dependency 'moab-versioning', '~> 4.0'

--- a/lib/dor/services/client/administrative_tags.rb
+++ b/lib/dor/services/client/administrative_tags.rb
@@ -60,6 +60,22 @@ module Dor
           JSON.parse(resp.body)
         end
 
+        # Get content type from administrative tags for an object
+        #
+        # @raise [NotFoundResponse] when the response is a 404 (object not found)
+        # @raise [UnexpectedResponse] if the request is unsuccessful.
+        # @return [String,NilClass] content type string or nil if none found
+        def content_type
+          resp = connection.get do |req|
+            req.url "#{api_version}/objects/#{object_identifier}/administrative_tags"
+            req.params['content_type_only'] = true
+          end
+
+          raise_exception_based_on_response!(resp, object_identifier) unless resp.success?
+
+          JSON.parse(resp.body).first
+        end
+
         # Updates an administrative tag for an object
         #
         # @param current [String] current tag to update

--- a/spec/dor/services/client/administrative_tags_spec.rb
+++ b/spec/dor/services/client/administrative_tags_spec.rb
@@ -49,6 +49,56 @@ RSpec.describe Dor::Services::Client::AdministrativeTags do
     end
   end
 
+  describe '#content_type' do
+    subject(:request) { client.content_type }
+
+    context 'when API request succeeds and there is a type' do
+      before do
+        stub_request(:get, "https://dor-services.example.com/v1/objects/#{druid}/administrative_tags?content_type_only=true")
+          .to_return(status: 200, body: '["Map"]')
+      end
+
+      it 'returns the content type tag' do
+        expect(request).to eq('Map')
+      end
+    end
+
+    context 'when API request succeeds and there is no type' do
+      before do
+        stub_request(:get, "https://dor-services.example.com/v1/objects/#{druid}/administrative_tags?content_type_only=true")
+          .to_return(status: 200, body: '[]')
+      end
+
+      it 'returns the content type tag' do
+        expect(request).to be nil
+      end
+    end
+
+    context 'when API request fails because of not found' do
+      before do
+        stub_request(:get, "https://dor-services.example.com/v1/objects/#{druid}/administrative_tags?content_type_only=true")
+          .to_return(status: [404, 'object not found'])
+      end
+
+      it 'raises an error' do
+        expect { request }.to raise_error(Dor::Services::Client::NotFoundResponse,
+                                          "object not found: 404 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY}) for #{druid}")
+      end
+    end
+
+    context 'when API request fails due to unexpected response' do
+      before do
+        stub_request(:get, "https://dor-services.example.com/v1/objects/#{druid}/administrative_tags?content_type_only=true")
+          .to_return(status: [500, 'something is amiss'])
+      end
+
+      it 'raises an error' do
+        expect { request }.to raise_error(Dor::Services::Client::UnexpectedResponse,
+                                          "something is amiss: 500 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY}) for #{druid}")
+      end
+    end
+  end
+
   describe '#create' do
     subject(:request) { client.create(tags: ['Registered By : mjgiarlo', 'Process : Content Type : Map']) }
 


### PR DESCRIPTION
Connects to sul-dlss/dor-services-app#679

## Why was this change made?

To allow apps to get the content type from admin tags. lyberservices-scripts needs this.

## Was the documentation (README, API, wiki, consul, etc.) updated?

Yes