### PR TITLE
Removes deprecated registering by hash.

### DIFF
--- a/lib/dor/services/client/objects.rb
+++ b/lib/dor/services/client/objects.rb
@@ -10,16 +10,11 @@ module Dor
       # API calls that are about a repository objects
       class Objects < VersionedService
         # Creates a new object in DOR
-        # @param [Hash,Cocina::Models::RequestDRO,Cocina::Models::RequestCollection,Cocina::Models::RequestAPO] passing a hash is deprecated
+        # @param [Cocina::Models::RequestDRO,Cocina::Models::RequestCollection,Cocina::Models::RequestAPO]
         # @return [HashWithIndifferentAccess] the response, which includes a :pid
         def register(params:)
-          if params.is_a? Hash
-            Deprecation.warn(self, 'passing a Hash to register is deprecated and will ' \
-              'be removed in dor-services-client 5.0. Use a Cocina::Models object instead.')
-          end
           json_str = register_response(params: params)
           json = JSON.parse(json_str)
-          return json.with_indifferent_access unless json.key?('type') # Legacy return
 
           Cocina::Models.build(json)
         end

--- a/spec/dor/services/client/objects_spec.rb
+++ b/spec/dor/services/client/objects_spec.rb
@@ -42,20 +42,6 @@ RSpec.describe Dor::Services::Client::Objects do
       end
     end
 
-    context 'when API request succeeds with a hash' do
-      before do
-        allow(Deprecation).to receive(:warn)
-      end
-      let(:params) { { foo: 'bar' } }
-      let(:expected_request) { '{"foo":"bar"}' }
-      let(:status) { 200 }
-      let(:body) { '{"pid":"druid:bc123df4567"}' }
-
-      it 'posts params as json' do
-        expect(client.register(params: params)[:pid]).to eq 'druid:bc123df4567'
-      end
-    end
-
     context 'when API request fails' do
       before do
         allow(Deprecation).to receive(:warn)


### PR DESCRIPTION
## Why was this change made?
Removing support for registering by hash in preparation for major release.

## Was the documentation (README, API, wiki, consul, etc.) updated?
No.