### PR TITLE
Separately raise exception when unauthorized.

### DIFF
--- a/lib/dor/services/client.rb
+++ b/lib/dor/services/client.rb
@@ -31,6 +31,9 @@ module Dor
       # this could be any 4xx or 5xx status
       class UnexpectedResponse < Error; end
 
+      # Error that is raised when the remote server returns a 401 Unauthorized
+      class UnauthorizedResponse < UnexpectedResponse; end
+
       # Error that is raised when the remote server returns some unparsable response
       class MalformedResponse < Error; end
 

--- a/lib/dor/services/client/versioned_service.rb
+++ b/lib/dor/services/client/versioned_service.rb
@@ -20,7 +20,15 @@ module Dor
         attr_reader :connection, :api_version
 
         def raise_exception_based_on_response!(response, object_identifier = nil)
-          raise (response.status == 404 ? NotFoundResponse : UnexpectedResponse),
+          exception_class = case response.status
+                            when 404
+                              NotFoundResponse
+                            when 401
+                              UnauthorizedResponse
+                            else
+                              UnexpectedResponse
+                            end
+          raise exception_class,
                 ResponseErrorFormatter.format(response: response, object_identifier: object_identifier)
         end
       end


### PR DESCRIPTION
refs https://github.com/sul-dlss/sdr-api/issues/172

## Why was this change made?
To allow a client to separately handle unauthorized.

## Was the documentation (README, API, wiki, consul, etc.) updated?
No.