### PR TITLE
Update cocina-models to 0.32.0

### DIFF
--- a/dor-services-client.gemspec
+++ b/dor-services-client.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport', '>= 4.2', '< 7'
-  spec.add_dependency 'cocina-models', '~> 0.31.0' # leave pinned to patch level until cocina-models hits 1.0
+  spec.add_dependency 'cocina-models', '~> 0.32.0' # leave pinned to patch level until cocina-models hits 1.0
   spec.add_dependency 'deprecation', '>= 0'
   spec.add_dependency 'faraday', '>= 0.15', '< 2'
   spec.add_dependency 'moab-versioning', '~> 4.0'

--- a/lib/dor/services/client/version.rb
+++ b/lib/dor/services/client/version.rb
@@ -3,7 +3,7 @@
 module Dor
   module Services
     class Client
-      VERSION = '5.1.0'
+      VERSION = '6.0.0.alpha'
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

To use the latest revision of cocina-models.

## Was the documentation (README, API, wiki, consul, etc.) updated?
no