### PR TITLE
Adds retries for GETS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,16 @@ private
 
 def client
   @client ||= Dor::Services::Client.configure(url: Settings.dor_services.url,
-                                              token: Settings.dor_services.token)
+                                              token: Settings.dor_services.token,
+                                              enable_get_retries: true)
 end
 ```
 
-Note that the client may **not** be used without first having been configured, and the `url` keyword is **required**. The `token` argument is optional (though when using the client with staging and production servers, you will always need to supply it in practice). For more about dor-services-app's token-based authentication, see [its README](https://github.com/sul-dlss/dor-services-app#authentication).
+Note:
+* The client may **not** be used without first having been configured
+* The `url` keyword is **required**.
+* The `token` argument is optional (though when using the client with staging and production servers, you will always need to supply it in practice). For more about dor-services-app's token-based authentication, see [its README](https://github.com/sul-dlss/dor-services-app#authentication).
+* The `enable_get_retries` argument is optional. When enabled, it will perform retries of `GET` requests only. This should only be used in situations in which blocking is not an issue, e.g., an asynchronous job.
 
 ## API Coverage
 

--- a/lib/dor/services/client/connection_wrapper.rb
+++ b/lib/dor/services/client/connection_wrapper.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Dor
+  module Services
+    class Client
+      # Wraps connections to allow GET requests to be retriable.
+      class ConnectionWrapper
+        delegate :get, to: :get_connection
+        delegate :post, :delete, :put, :patch, to: :connection
+
+        def initialize(connection:, get_connection:)
+          @connection = connection
+          @get_connection = get_connection
+        end
+
+        private
+
+        attr_reader :connection, :get_connection
+      end
+    end
+  end
+end

--- a/spec/dor/services/client/connection_wrapper_spec.rb
+++ b/spec/dor/services/client/connection_wrapper_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+RSpec.describe Dor::Services::Client::ConnectionWrapper do
+  subject(:connection_wrapper) { described_class.new(connection: connection, get_connection: get_connection) }
+  let(:connection) { instance_double(Faraday::Connection, post: true, put: true, patch: true, delete: true) }
+
+  let(:get_connection) { instance_double(Faraday::Connection, get: true) }
+
+  describe '.get' do
+    before do
+      connection_wrapper.get
+    end
+    it 'invokes get_connection' do
+      expect(get_connection).to have_received(:get)
+    end
+  end
+
+  describe '.post' do
+    before do
+      connection_wrapper.post
+    end
+    it 'invokes connection' do
+      expect(connection).to have_received(:post)
+    end
+  end
+
+  describe '.put' do
+    before do
+      connection_wrapper.put
+    end
+    it 'invokes connection' do
+      expect(connection).to have_received(:put)
+    end
+  end
+
+  describe '.patch' do
+    before do
+      connection_wrapper.patch
+    end
+    it 'invokes connection' do
+      expect(connection).to have_received(:patch)
+    end
+  end
+
+  describe '.delete' do
+    before do
+      connection_wrapper.delete
+    end
+    it 'invokes connection' do
+      expect(connection).to have_received(:delete)
+    end
+  end
+end

--- a/spec/dor/services/client_spec.rb
+++ b/spec/dor/services/client_spec.rb
@@ -81,12 +81,26 @@ RSpec.describe Dor::Services::Client do
     it 'returns Client class' do
       expect(client).to eq Dor::Services::Client
     end
+  end
+
+  describe '#build_connection' do
+    subject(:client) { described_class.configure(url: 'https://dor-services.example.com', token: '123', enable_get_retries: true) }
 
     it 'sets the token on the connection using the default authorization header' do
-      expect(described_class.instance.send(:connection).headers).to include(
+      expect(client.instance.send(:build_connection).headers).to include(
         described_class::TOKEN_HEADER => 'Bearer 123',
         'User-Agent' => /dor-services-client \d+\.\d+\.\d+/
       )
+    end
+
+    it 'does not enable retries' do
+      expect(client.instance.send(:build_connection).builder.handlers).not_to include(Faraday::Request::Retry)
+    end
+
+    context 'when with retries' do
+      it 'enables retries' do
+        expect(client.instance.send(:build_connection, with_retries: true).builder.handlers).to include(Faraday::Request::Retry)
+      end
     end
   end
 end


### PR DESCRIPTION
closes #168

## Why was this change made?
To allow retries to make calls to dor-services-app more resilient.

## Was the documentation (README, API, wiki, consul, etc.) updated?
Yes.