### PR TITLE
Defer to default Faraday retry exceptions.

### DIFF
--- a/lib/dor/services/client.rb
+++ b/lib/dor/services/client.rb
@@ -125,10 +125,7 @@ module Dor
           builder.adapter Faraday.default_adapter
           builder.headers[:user_agent] = user_agent
           builder.headers[TOKEN_HEADER] = "Bearer #{token}"
-          if with_retries
-            builder.request :retry, max: 4, interval: 1,
-                                    backoff_factor: 2, exceptions: ['Faraday::Error', 'Timeout::Error']
-          end
+          builder.request :retry, max: 4, interval: 1, backoff_factor: 2 if with_retries
         end
       end
 


### PR DESCRIPTION
## Why was this change made?
Still getting some timeout errors. The default list is more comprehensive.

## Was the documentation (README, API, wiki, consul, etc.) updated?
No.