### PR TITLE
Adds separate exception for 409.

### DIFF
--- a/lib/dor/services/client.rb
+++ b/lib/dor/services/client.rb
@@ -36,6 +36,9 @@ module Dor
       # Error that is raised when the remote server returns a 401 Unauthorized
       class UnauthorizedResponse < UnexpectedResponse; end
 
+      # Error that is raised when the remote server returns a 409 Conflict
+      class ConflictResponse < UnexpectedResponse; end
+
       # Error that is raised when the remote server returns some unparsable response
       class MalformedResponse < Error; end
 

--- a/lib/dor/services/client/versioned_service.rb
+++ b/lib/dor/services/client/versioned_service.rb
@@ -19,18 +19,22 @@ module Dor
 
         attr_reader :connection, :api_version
 
+        # rubocop:disable Metrics/MethodLength
         def raise_exception_based_on_response!(response, object_identifier = nil)
           exception_class = case response.status
                             when 404
                               NotFoundResponse
                             when 401
                               UnauthorizedResponse
+                            when 409
+                              ConflictResponse
                             else
                               UnexpectedResponse
                             end
           raise exception_class,
                 ResponseErrorFormatter.format(response: response, object_identifier: object_identifier)
         end
+        # rubocop:enable Metrics/MethodLength
       end
     end
   end

--- a/spec/dor/services/client/objects_spec.rb
+++ b/spec/dor/services/client/objects_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Dor::Services::Client::Objects do
         let(:body) { nil }
 
         it 'raises an error' do
-          expect { client.register(params: model) }.to raise_error(Dor::Services::Client::UnexpectedResponse,
+          expect { client.register(params: model) }.to raise_error(Dor::Services::Client::ConflictResponse,
                                                                    "object already exists: 409 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY})")
         end
       end


### PR DESCRIPTION
## Why was this change made?
So that a 409 could be rescued without parsing message.

## Was the documentation (README, API, wiki, consul, etc.) updated?
No.