### PR TITLE
Support legacy metadata update of geoMetadata

### DIFF
--- a/lib/dor/services/client/metadata.rb
+++ b/lib/dor/services/client/metadata.rb
@@ -21,10 +21,11 @@ module Dor
         # @option opts [Hash] :identity Data for identity metadata
         # @option opts [Hash] :technical Data for technical metadata
         # @option opts [Hash] :provenance Data for provenance metadata
+        # @option opts [Hash] :geo Data for geographic metadata
         # @example:
         #  legacy_update(descriptive: { updated: '2001-12-20', content: '<descMetadata />' })
         def legacy_update(opts)
-          opts = opts.slice(:descriptive, :rights, :identity, :content, :technical, :provenance)
+          opts = opts.slice(:descriptive, :rights, :identity, :content, :technical, :provenance, :geo)
           resp = connection.patch do |req|
             req.url "#{base_path}/legacy"
             req.headers['Content-Type'] = 'application/json'

--- a/spec/dor/services/client/metadata_spec.rb
+++ b/spec/dor/services/client/metadata_spec.rb
@@ -83,7 +83,8 @@ RSpec.describe Dor::Services::Client::Metadata do
       let(:params) do
         {
           descriptive: { updated: Time.find_zone('UTC').parse('2020-01-05'), content: '<descMetadata/>' },
-          identity: { updated: Time.find_zone('UTC').parse('2020-01-05'), content: '<identityMetadata/>' }
+          identity: { updated: Time.find_zone('UTC').parse('2020-01-05'), content: '<identityMetadata/>' },
+          geo: { updated: Time.find_zone('UTC').parse('2020-01-05'), content: '<geoMetadata/>' }
         }
       end
 
@@ -91,7 +92,8 @@ RSpec.describe Dor::Services::Client::Metadata do
         stub_request(:patch, 'https://dor-services.example.com/v1/objects/druid:1234/metadata/legacy')
           .with(
             body: '{"descriptive":{"updated":"2020-01-05T00:00:00.000Z","content":"\\u003cdescMetadata/\\u003e"},' \
-                  '"identity":{"updated":"2020-01-05T00:00:00.000Z","content":"\\u003cidentityMetadata/\\u003e"}}',
+                  '"identity":{"updated":"2020-01-05T00:00:00.000Z","content":"\\u003cidentityMetadata/\\u003e"},' \
+                  '"geo":{"updated":"2020-01-05T00:00:00.000Z","content":"\\u003cgeoMetadata/\\u003e"}}',
             headers: { 'Content-Type' => 'application/json' }
           )
           .to_return(status: status)


### PR DESCRIPTION
## Why was this change made?
So we can decouple gis-robot-suite from fedora 3.


## How was this change tested?

Test suite

## Which documentation and/or configurations were updated?

n/a

