### PR TITLE
Correct YARD doc for `AdministrativeTags#list`

### DIFF
--- a/lib/dor/services/client/administrative_tags.rb
+++ b/lib/dor/services/client/administrative_tags.rb
@@ -49,7 +49,7 @@ module Dor
         #
         # @raise [NotFoundResponse] when the response is a 404 (object not found)
         # @raise [UnexpectedResponse] if the request is unsuccessful.
-        # @return [Hash]
+        # @return [Array<String>]
         def list
           resp = connection.get do |req|
             req.url "#{api_version}/objects/#{object_identifier}/administrative_tags"


### PR DESCRIPTION
It returns an array of strings, not a hash.

## Why was this change made?

For more accurate docs.

## How was this change tested?

n/a

## Which documentation and/or configurations were updated?

YARD doc for the offending method.

