### PR TITLE
Avoid passing kwargs as the last argument

### DIFF
--- a/lib/dor/services/client/object.rb
+++ b/lib/dor/services/client/object.rb
@@ -16,39 +16,39 @@ module Dor
         end
 
         def metadata
-          @metadata ||= Metadata.new(parent_params)
+          @metadata ||= Metadata.new(**parent_params)
         end
 
         def events
-          @events ||= Events.new(parent_params)
+          @events ||= Events.new(**parent_params)
         end
 
         def files
-          @files ||= Files.new(parent_params)
+          @files ||= Files.new(**parent_params)
         end
 
         def workspace
-          @workspace ||= Workspace.new(parent_params)
+          @workspace ||= Workspace.new(**parent_params)
         end
 
         def release_tags
-          @release_tags ||= ReleaseTags.new(parent_params)
+          @release_tags ||= ReleaseTags.new(**parent_params)
         end
 
         def administrative_tags
-          @administrative_tags ||= AdministrativeTags.new(parent_params)
+          @administrative_tags ||= AdministrativeTags.new(**parent_params)
         end
 
         def version
-          @version ||= ObjectVersion.new(parent_params)
+          @version ||= ObjectVersion.new(**parent_params)
         end
 
         def embargo
-          @embargo ||= Embargo.new(parent_params)
+          @embargo ||= Embargo.new(**parent_params)
         end
 
         def accession(params = {})
-          @accession ||= Accession.new(parent_params.merge(params))
+          @accession ||= Accession.new(**parent_params.merge(params))
         end
 
         # Retrieves the Cocina model
@@ -88,14 +88,14 @@ module Dor
         # @raise [UnexpectedResponse] if the request is unsuccessful.
         # @return [Array<Cocina::Models::DRO>]
         def collections
-          Collections.new(parent_params).collections
+          Collections.new(**parent_params).collections
         end
 
         # Get a list of the members
         # @raise [UnexpectedResponse] if the request is unsuccessful.
         # @return [Array<Members::Member>]
         def members
-          Members.new(parent_params).members
+          Members.new(**parent_params).members
         end
 
         # Publish an object (send to PURL)

--- a/spec/dor/services/client/embargo_spec.rb
+++ b/spec/dor/services/client/embargo_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Dor::Services::Client::Embargo do
       let(:status) { 204 }
 
       it 'posts params as json' do
-        expect(client.update(params)).to be_nil
+        expect(client.update(**params)).to be_nil
       end
     end
 
@@ -37,7 +37,7 @@ RSpec.describe Dor::Services::Client::Embargo do
       let(:status) { [404, 'not found'] }
 
       it 'raises an error' do
-        expect { client.update(params) }.to(
+        expect { client.update(**params) }.to(
           raise_error(Dor::Services::Client::NotFoundResponse,
                       "not found: 404 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY}) for druid:1234")
         )


### PR DESCRIPTION


## Why was this change made?
This is deprecated and without adding the **, a warning is emitted


## How was this change tested?

Test suite

## Which documentation and/or configurations were updated?
n/a


