### PR TITLE
[HOLD] Support updating embargo metadata via the legacy API

### DIFF
--- a/lib/dor/services/client/metadata.rb
+++ b/lib/dor/services/client/metadata.rb
@@ -16,6 +16,7 @@ module Dor
         # Updates using the legacy SDR/Fedora3 metadata
         # @param [Hash<Symbol,Hash>] opts the options for legacy update
         # @option opts [Hash] :descriptive Data for descriptive metadata
+        # @option opts [Hash] :embargo Data for embargo metadata
         # @option opts [Hash] :rights Data for access rights metadata
         # @option opts [Hash] :content Data for structural metadata
         # @option opts [Hash] :identity Data for identity metadata
@@ -25,7 +26,7 @@ module Dor
         # @example:
         #  legacy_update(descriptive: { updated: '2001-12-20', content: '<descMetadata />' })
         def legacy_update(opts)
-          opts = opts.slice(:descriptive, :rights, :identity, :content, :technical, :provenance, :geo)
+          opts = opts.slice(:descriptive, :embargo, :rights, :identity, :content, :technical, :provenance, :geo)
           resp = connection.patch do |req|
             req.url "#{base_path}/legacy"
             req.headers['Content-Type'] = 'application/json'

--- a/spec/dor/services/client/metadata_spec.rb
+++ b/spec/dor/services/client/metadata_spec.rb
@@ -83,6 +83,7 @@ RSpec.describe Dor::Services::Client::Metadata do
       let(:params) do
         {
           descriptive: { updated: Time.find_zone('UTC').parse('2020-01-05'), content: '<descMetadata/>' },
+          embargo: { updated: Time.find_zone('UTC').parse('2020-01-05'), content: '<embargoMetadata/>' },
           identity: { updated: Time.find_zone('UTC').parse('2020-01-05'), content: '<identityMetadata/>' },
           geo: { updated: Time.find_zone('UTC').parse('2020-01-05'), content: '<geoMetadata/>' }
         }
@@ -92,6 +93,7 @@ RSpec.describe Dor::Services::Client::Metadata do
         stub_request(:patch, 'https://dor-services.example.com/v1/objects/druid:1234/metadata/legacy')
           .with(
             body: '{"descriptive":{"updated":"2020-01-05T00:00:00.000Z","content":"\\u003cdescMetadata/\\u003e"},' \
+                  '"embargo":{"updated":"2020-01-05T00:00:00.000Z","content":"\\u003cembargoMetadata/\\u003e"},' \
                   '"identity":{"updated":"2020-01-05T00:00:00.000Z","content":"\\u003cidentityMetadata/\\u003e"},' \
                   '"geo":{"updated":"2020-01-05T00:00:00.000Z","content":"\\u003cgeoMetadata/\\u003e"}}',
             headers: { 'Content-Type' => 'application/json' }


### PR DESCRIPTION
## Why was this change made?

So we can send embargo metadata to the Dor-services API

## How was this change tested?

Test suite

## Which documentation and/or configurations were updated?

n/a

