### PR TITLE
Upgrade cocina-models to 0.34.1

### DIFF
--- a/dor-services-client.gemspec
+++ b/dor-services-client.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport', '>= 4.2', '< 7'
-  spec.add_dependency 'cocina-models', '~> 0.33.0' # leave pinned to patch level until cocina-models hits 1.0
+  spec.add_dependency 'cocina-models', '~> 0.34.1' # leave pinned to patch level until cocina-models hits 1.0
   spec.add_dependency 'deprecation', '>= 0'
   spec.add_dependency 'faraday', '>= 0.15', '< 2'
   spec.add_dependency 'moab-versioning', '~> 4.0'

--- a/spec/dor/services/client/object_spec.rb
+++ b/spec/dor/services/client/object_spec.rb
@@ -111,6 +111,9 @@ RSpec.describe Dor::Services::Client::Object do
             "type":"http://cocina.sul.stanford.edu/models/book.jsonld",
             "label":"my item",
             "version":1,
+            "administrative":{
+              "hasAdminPolicy":"druid:fv123df4567"
+            },
             "description":{
               "title": [
                 { "value": "hey!", "type": "primary" }
@@ -177,6 +180,9 @@ RSpec.describe Dor::Services::Client::Object do
             "type":"http://cocina.sul.stanford.edu/models/book.jsonld",
             "label":"my item",
             "version":1,
+            "administrative":{
+              "hasAdminPolicy":"druid:fv123df4567"
+            },
             "description":{
               "title": [
                 { "value": "hey!", "type": "primary" }

--- a/spec/dor/services/client/objects_spec.rb
+++ b/spec/dor/services/client/objects_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Dor::Services::Client::Objects do
       type: item_type,
       label: 'My object',
       version: 3,
+      administrative: { hasAdminPolicy: 'druid:fv123df4567' },
       identification: { sourceId: 'sul:99999' }
     }
   end


### PR DESCRIPTION
## Why was this change made?
To use the latest cocina-models client which requires an APO.


## How was this change tested?

Test suite.

## Which documentation and/or configurations were updated?

n/a

