### PR TITLE
use cocina-models v0.44.0

### DIFF
--- a/dor-services-client.gemspec
+++ b/dor-services-client.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport', '>= 4.2', '< 7'
-  spec.add_dependency 'cocina-models', '~> 0.43.0' # leave pinned to patch level until cocina-models hits 1.0
+  spec.add_dependency 'cocina-models', '~> 0.44.0' # leave pinned to patch level until cocina-models hits 1.0
   spec.add_dependency 'deprecation', '>= 0'
   spec.add_dependency 'faraday', '>= 0.15', '< 2'
   spec.add_dependency 'moab-versioning', '~> 4.0'


### PR DESCRIPTION
## Why was this change made?

For mapping ticket sul-dlss/dor-services-app#1499, we needed a tiny additive change in cocina-models 0.44.0.  This change is in dor-services-app with PR sul-dlss/dor-services-app/pull/1686.  

## How was this change tested?



## Which documentation and/or configurations were updated?



