### PR TITLE
add method to get source mods for a dor object

### DIFF
--- a/lib/dor/services/client/metadata.rb
+++ b/lib/dor/services/client/metadata.rb
@@ -51,11 +51,23 @@ module Dor
           raise_exception_based_on_response!(resp, object_identifier)
         end
 
-        # @return [String, NilClass] The descriptive metadata XML representation of the object or nil if response is 404
+        # @return [String, NilClass] The public descriptive metadata XML representation of the object or nil if response is 404
         # @raise [UnexpectedResponse] on an unsuccessful response from the server
         def descriptive
           resp = connection.get do |req|
             req.url "#{base_path}/descriptive"
+          end
+          return resp.body if resp.success?
+          return if resp.status == 404
+
+          raise_exception_based_on_response!(resp, object_identifier)
+        end
+
+        # @return [String, NilClass] the dor object's source MODS XML or nil if response is 404
+        # @raise [UnexpectedResponse] on an unsuccessful response from the server
+        def mods
+          resp = connection.get do |req|
+            req.url "#{base_path}/mods"
           end
           return resp.body if resp.success?
           return if resp.status == 404

--- a/spec/dor/services/client/metadata_spec.rb
+++ b/spec/dor/services/client/metadata_spec.rb
@@ -55,9 +55,42 @@ RSpec.describe Dor::Services::Client::Metadata do
 
     context 'when the object is found' do
       let(:status) { 200 }
-      let(:body) { '<dc />' }
+      let(:body) { '<publicObject />' }
 
-      it { is_expected.to eq '<dc />' }
+      it { is_expected.to eq '<publicObject />' }
+    end
+
+    context 'when the object is not found' do
+      let(:status) { 404 }
+      let(:body) { '' }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when there is a server error' do
+      let(:status) { [500, 'internal server error'] }
+      let(:body) { 'broken' }
+
+      it 'raises an error' do
+        expect { response }.to raise_error(Dor::Services::Client::UnexpectedResponse,
+                                           'internal server error: 500 (broken) for druid:1234')
+      end
+    end
+  end
+
+  describe '#mods' do
+    subject(:response) { client.mods }
+
+    before do
+      stub_request(:get, 'https://dor-services.example.com/v1/objects/druid:1234/metadata/mods')
+        .to_return(status: status, body: body)
+    end
+
+    context 'when the object is found' do
+      let(:status) { 200 }
+      let(:body) { '<mods />' }
+
+      it { is_expected.to eq '<mods />' }
     end
 
     context 'when the object is not found' do


### PR DESCRIPTION
~~wait for sul-dlss/dor-services-app/pull/2487 to be merged~~

## Why was this change made?

So Argo can request source MODS without having to access Fedora directly.  Depends on PR sul-dlss/dor-services-app/pull/2487 being merged, of course.

Closes #202 

## How was this change tested?

unit tests

## Which documentation and/or configurations were updated?



