### PR TITLE
Add method for version inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ object_client.apply_admin_policy_defaults
 object_client.notify_goobi
 
 # Manage versions
+object_client.version.inventory
 object_client.version.current
 object_client.version.openable?(**params)
 object_client.version.open(**params)

--- a/spec/dor/services/client/object_version_spec.rb
+++ b/spec/dor/services/client/object_version_spec.rb
@@ -60,6 +60,64 @@ RSpec.describe Dor::Services::Client::ObjectVersion do
     end
   end
 
+  describe '#inventory' do
+    subject(:request) { client.inventory }
+
+    before do
+      stub_request(:get, 'https://dor-services.example.com/v1/objects/druid:1234/versions')
+        .to_return(status: status, body: body)
+    end
+
+    context 'when API request succeeds' do
+      let(:status) { 200 }
+      let(:body) do
+        <<~JSON
+          {"versions":[
+            {"versionId":1,"tag":"1.0.0","message":"Initial version"},
+            {"versionId":2,"tag":"2.0.0","message":"Updated"}
+          ]}
+        JSON
+      end
+
+      it 'returns the list of versions' do
+        expect(request).to eq [
+          described_class::Version.new(versionId: 1, tag: '1.0.0', message: 'Initial version'),
+          described_class::Version.new(versionId: 2, tag: '2.0.0', message: 'Updated')
+        ]
+      end
+    end
+
+    context 'when API request returns 404' do
+      let(:status) { [404, 'not found'] }
+      let(:body) { '' }
+
+      it 'raises a NotFoundResponse exception' do
+        expect { request }.to raise_error(Dor::Services::Client::NotFoundResponse)
+      end
+    end
+
+    context 'when API request fails' do
+      let(:status) { [401, 'unauthorized'] }
+      let(:body) { '' }
+
+      it 'raises an error' do
+        expect { request }.to raise_error(Dor::Services::Client::UnauthorizedResponse)
+      end
+    end
+
+    context 'when connection fails' do
+      before do
+        allow_any_instance_of(Faraday::Adapter::NetHttp).to receive(:call).and_raise(Faraday::ConnectionFailed.new('end of file reached'))
+      end
+      let(:status) { 555 }
+      let(:body) { '' }
+
+      it 'raises an error' do
+        expect { request }.to raise_error(Dor::Services::Client::ConnectionFailed, 'unable to reach dor-services-app')
+      end
+    end
+  end
+
   describe '#open_new_version' do
     let(:params) { {} }
 


### PR DESCRIPTION
## Why was this change made?

To decouple Argo from Fedora 3

Ref https://github.com/sul-dlss/dor-services-app/pull/2536
Ref https://github.com/sul-dlss/argo/issues/2415


## How was this change tested?



## Which documentation and/or configurations were updated?



