### PR TITLE
Add a method to return the contents of any datastream

### DIFF
--- a/lib/dor/services/client/metadata.rb
+++ b/lib/dor/services/client/metadata.rb
@@ -75,6 +75,33 @@ module Dor
           raise_exception_based_on_response!(resp, object_identifier)
         end
 
+        # rubocop:disable Lint/StructNewOverride
+        Datastream = Struct.new(:label, :dsid, :pid, :size, :mimeType, keyword_init: true)
+        # rubocop:enable Lint/StructNewOverride
+
+        # @return [Array] the list of datastreams for the item
+        # @raise [UnexpectedResponse] on an unsuccessful response from the server
+        def datastreams
+          resp = connection.get do |req|
+            req.url "#{base_path}/datastreams"
+          end
+          raise_exception_based_on_response!(resp, object_identifier) unless resp.success?
+
+          JSON.parse(resp.body).map { |params| Datastream.new(**params) }
+        end
+
+        # @param [String] dsid the identifier for the datastream
+        # @return [String] the contents of the specified datastream
+        # @raise [UnexpectedResponse] on an unsuccessful response from the server
+        def datastream(dsid)
+          resp = connection.get do |req|
+            req.url "#{base_path}/datastreams/#{dsid}"
+          end
+          raise_exception_based_on_response!(resp, object_identifier) unless resp.success?
+
+          resp.body
+        end
+
         private
 
         attr_reader :object_identifier

--- a/spec/dor/services/client/metadata_spec.rb
+++ b/spec/dor/services/client/metadata_spec.rb
@@ -185,4 +185,97 @@ RSpec.describe Dor::Services::Client::Metadata do
       end
     end
   end
+
+  describe '#datastreams' do
+    subject(:request) { client.datastreams }
+
+    before do
+      stub_request(:get, 'https://dor-services.example.com/v1/objects/druid:1234/metadata/datastreams')
+        .to_return(status: status, body: body)
+    end
+
+    context 'when API request succeeds' do
+      let(:status) { 200 }
+      let(:body) do
+        <<~JSON
+          [
+            {"label":"descriptive metadata","dsid":"descMetadata","pid":"druid:1234","size":"14","mimeType":"application/xml"},
+            {"label":"content metadata","dsid":"contentMetadata","pid":"druid:1234","size":"22","mimeType":"application/xml"}
+          ]
+        JSON
+      end
+
+      it 'returns the list of versions' do
+        expect(request).to eq [
+          described_class::Datastream.new(label: 'descriptive metadata', dsid: 'descMetadata', pid: 'druid:1234', size: '14', mimeType: 'application/xml'),
+          described_class::Datastream.new(label: 'content metadata', dsid: 'contentMetadata', pid: 'druid:1234', size: '22', mimeType: 'application/xml')
+        ]
+      end
+    end
+
+    context 'when API request returns 404' do
+      let(:status) { [404, 'not found'] }
+      let(:body) { '' }
+
+      it 'raises a NotFoundResponse exception' do
+        expect { request }.to raise_error(Dor::Services::Client::NotFoundResponse)
+      end
+    end
+
+    context 'when API request fails' do
+      let(:status) { [401, 'unauthorized'] }
+      let(:body) { '' }
+
+      it 'raises an error' do
+        expect { request }.to raise_error(Dor::Services::Client::UnauthorizedResponse)
+      end
+    end
+
+    context 'when connection fails' do
+      before do
+        allow_any_instance_of(Faraday::Adapter::NetHttp).to receive(:call).and_raise(Faraday::ConnectionFailed.new('end of file reached'))
+      end
+      let(:status) { 555 }
+      let(:body) { '' }
+
+      it 'raises an error' do
+        expect { request }.to raise_error(Dor::Services::Client::ConnectionFailed, 'unable to reach dor-services-app')
+      end
+    end
+  end
+
+  describe '#datastream' do
+    subject(:response) { client.datastream('descMetadata') }
+
+    before do
+      stub_request(:get, 'https://dor-services.example.com/v1/objects/druid:1234/metadata/datastreams/descMetadata')
+        .to_return(status: status, body: body)
+    end
+
+    context 'when the object is found' do
+      let(:status) { 200 }
+      let(:body) { '<mods />' }
+
+      it { is_expected.to eq '<mods />' }
+    end
+
+    context 'when the object is not found' do
+      let(:status) { 404 }
+      let(:body) { '' }
+
+      it 'raises an error' do
+        expect { response }.to raise_error Dor::Services::Client::NotFoundResponse
+      end
+    end
+
+    context 'when there is a server error' do
+      let(:status) { [500, 'internal server error'] }
+      let(:body) { 'broken' }
+
+      it 'raises an error' do
+        expect { response }.to raise_error(Dor::Services::Client::UnexpectedResponse,
+                                           'internal server error: 500 (broken) for druid:1234')
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made?

So we can decouple argo from datastreams

## How was this change tested?



## Which documentation and/or configurations were updated?



