### PR TITLE
Add missing datastream version field

### DIFF
--- a/lib/dor/services/client/metadata.rb
+++ b/lib/dor/services/client/metadata.rb
@@ -76,7 +76,7 @@ module Dor
         end
 
         # rubocop:disable Lint/StructNewOverride
-        Datastream = Struct.new(:label, :dsid, :pid, :size, :mimeType, keyword_init: true)
+        Datastream = Struct.new(:label, :dsid, :pid, :size, :mimeType, :versionId, keyword_init: true)
         # rubocop:enable Lint/StructNewOverride
 
         # @return [Array] the list of datastreams for the item

--- a/spec/dor/services/client/metadata_spec.rb
+++ b/spec/dor/services/client/metadata_spec.rb
@@ -199,16 +199,18 @@ RSpec.describe Dor::Services::Client::Metadata do
       let(:body) do
         <<~JSON
           [
-            {"label":"descriptive metadata","dsid":"descMetadata","pid":"druid:1234","size":"14","mimeType":"application/xml"},
-            {"label":"content metadata","dsid":"contentMetadata","pid":"druid:1234","size":"22","mimeType":"application/xml"}
+            {"label":"descriptive metadata","dsid":"descMetadata","pid":"druid:1234","size":"14","mimeType":"application/xml","versionId":"v0"},
+            {"label":"content metadata","dsid":"contentMetadata","pid":"druid:1234","size":"22","mimeType":"application/xml","versionId":"v5"}
           ]
         JSON
       end
 
       it 'returns the list of versions' do
         expect(request).to eq [
-          described_class::Datastream.new(label: 'descriptive metadata', dsid: 'descMetadata', pid: 'druid:1234', size: '14', mimeType: 'application/xml'),
-          described_class::Datastream.new(label: 'content metadata', dsid: 'contentMetadata', pid: 'druid:1234', size: '22', mimeType: 'application/xml')
+          described_class::Datastream.new(label: 'descriptive metadata', dsid: 'descMetadata', pid: 'druid:1234', size: '14', versionId: 'v0',
+                                          mimeType: 'application/xml'),
+          described_class::Datastream.new(label: 'content metadata', dsid: 'contentMetadata', pid: 'druid:1234', size: '22', versionId: 'v5',
+                                          mimeType: 'application/xml')
         ]
       end
     end


### PR DESCRIPTION
## Why was this change made?

Ref https://github.com/sul-dlss/dor-services-app/pull/2550
Ref https://github.com/sul-dlss/argo/pull/2522#issuecomment-802269717

## How was this change tested?



## Which documentation and/or configurations were updated?



