### PR TITLE
Bump cocina-models dependency to 0.58.0

### DIFF
--- a/dor-services-client.gemspec
+++ b/dor-services-client.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '~> 2.6'
 
   spec.add_dependency 'activesupport', '>= 4.2', '< 7'
-  spec.add_dependency 'cocina-models', '~> 0.57.0' # leave pinned to patch level until cocina-models hits 1.0
+  spec.add_dependency 'cocina-models', '~> 0.58.0' # leave pinned to patch level until cocina-models hits 1.0
   spec.add_dependency 'deprecation', '>= 0'
   spec.add_dependency 'faraday', '>= 0.15', '< 2'
   spec.add_dependency 'moab-versioning', '~> 4.0'


### PR DESCRIPTION
## Why was this change made?
So that we can set non-required values from something that exists to nil.


## How was this change tested?



## Which documentation and/or configurations were updated?



