### PR TITLE
allow cleanup method to be sent lane-id and pass to dor-services-step

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ object_client.events.list
 
 # Create, remove, and reset workspaces
 object_client.workspace.create(source: object_path_string)
-object_client.workspace.cleanup
+object_client.workspace.cleanup(lane_id: 'low')
 object_client.workspace.reset
 
 # Search for administrative tags:

--- a/lib/dor/services/client/workspace.rb
+++ b/lib/dor/services/client/workspace.rb
@@ -25,10 +25,11 @@ module Dor
 
         # Cleans up a workspace
         # @raise [UnexpectedResponse] if the request is unsuccessful.
+        # @param [String] lane_id for prioritization (default or low)
         # @return nil
-        def cleanup
+        def cleanup(lane_id: nil)
           resp = connection.delete do |req|
-            req.url workspace_path
+            req.url workspace_path(lane_id: lane_id)
           end
           raise_exception_based_on_response!(resp, object_identifier) unless resp.success?
         end
@@ -46,8 +47,9 @@ module Dor
 
         private
 
-        def workspace_path
-          "#{api_version}/objects/#{object_identifier}/workspace"
+        def workspace_path(lane_id: nil)
+          query_string = lane_id ? "?lane-id=#{lane_id}" : ''
+          "#{api_version}/objects/#{object_identifier}/workspace#{query_string}"
         end
 
         attr_reader :object_identifier

--- a/spec/dor/services/client/workspace_spec.rb
+++ b/spec/dor/services/client/workspace_spec.rb
@@ -38,11 +38,11 @@ RSpec.describe Dor::Services::Client::Workspace do
   end
 
   describe '#cleanup' do
-    subject(:request) { client.cleanup }
+    subject(:request) { client.cleanup(lane_id: 1) }
 
     context 'when API request succeeds' do
       before do
-        stub_request(:delete, 'https://dor-services.example.com/v1/objects/druid:123/workspace')
+        stub_request(:delete, 'https://dor-services.example.com/v1/objects/druid:123/workspace?lane-id=1')
           .to_return(status: 200)
       end
 
@@ -53,7 +53,7 @@ RSpec.describe Dor::Services::Client::Workspace do
 
     context 'when API request fails' do
       before do
-        stub_request(:delete, 'https://dor-services.example.com/v1/objects/druid:123/workspace')
+        stub_request(:delete, 'https://dor-services.example.com/v1/objects/druid:123/workspace?lane-id=1')
           .to_return(status: [500, 'something is amiss'])
       end
 


### PR DESCRIPTION
## Why was this change made?

Part of sul-dlss/argo#2752

Experiment in switching the end-accession/cleanup to a job.  This allows the client to accept a lane-id and pass it along to dor-services-app.

We also need to changes to dor-services-app: sul-dlss/dor-services-app#2885 and common-accessioning: sul-dlss/common-accessioning#770.  Hold for these changes since they all need to be released together.

## How was this change tested?

Updated spec.

## Which documentation and/or configurations were updated?

In the README
