### PR TITLE
add BadRequestError

### DIFF
--- a/lib/dor/services/client.rb
+++ b/lib/dor/services/client.rb
@@ -26,11 +26,17 @@ module Dor
       # Base class for Dor::Services::Client exceptions
       class Error < StandardError; end
 
-      # Error that is raised when the remote server returns a 404 Not Found
+      # Error that is raised when the ultimate remote server returns a 404 Not Found for the id in our request (e.g. for druid, barcode, catkey)
       class NotFoundResponse < Error; end
 
+      # Error that is raised when the remote server returns some unparsable response
+      class MalformedResponse < Error; end
+
+      # Error that wraps Faraday connection exceptions
+      class ConnectionFailed < Error; end
+
       # Error that is raised when the remote server returns some unexpected response
-      # this could be any 4xx or 5xx status
+      # this could be any 4xx or 5xx status (except the ones that are direct children of the Error class above)
       class UnexpectedResponse < Error; end
 
       # Error that is raised when the remote server returns a 401 Unauthorized
@@ -39,11 +45,8 @@ module Dor
       # Error that is raised when the remote server returns a 409 Conflict
       class ConflictResponse < UnexpectedResponse; end
 
-      # Error that is raised when the remote server returns some unparsable response
-      class MalformedResponse < Error; end
-
-      # Error that wraps Faraday connection exceptions
-      class ConnectionFailed < Error; end
+      # Error that is raised when the remote server returns a 400 Bad Request; apps should not retry the request
+      class BadRequestError < UnexpectedResponse; end
 
       # @param object_identifier [String] the pid for the object
       # @raise [ArgumentError] when `object_identifier` is `nil`

--- a/lib/dor/services/client/marcxml.rb
+++ b/lib/dor/services/client/marcxml.rb
@@ -21,6 +21,7 @@ module Dor
           return resp.body if resp.success? && resp.body.present?
 
           # This method needs its own exception handling logic due to how the endpoint service (SearchWorks) operates
+          # raise a NotFoundResponse because the resource being requested was not found in the ILS (via dor-services-app)
           raise NotFoundResponse, ResponseErrorFormatter.format(response: resp) if resp.success? && resp.body.blank?
 
           raise UnexpectedResponse, ResponseErrorFormatter.format(response: resp)
@@ -42,10 +43,12 @@ module Dor
           end
 
           # This method needs its own exception handling logic due to how the endpoint service (Symphony) operates
-          #
+
           # DOR Services App does not respond with a 404 when no match in Symphony.
           # Rather, it responds with a 500 containing "Record not found in Symphony" in the body.
+          # raise a NotFoundResponse because the resource being requested was not found in the ILS (via dor-services-app)
           raise NotFoundResponse, ResponseErrorFormatter.format(response: resp) if !resp.success? && resp.body.match?(/Record not found in Symphony/)
+
           raise UnexpectedResponse, ResponseErrorFormatter.format(response: resp) unless resp.success?
 
           resp.body

--- a/lib/dor/services/client/versioned_service.rb
+++ b/lib/dor/services/client/versioned_service.rb
@@ -22,10 +22,12 @@ module Dor
         # rubocop:disable Metrics/MethodLength
         def raise_exception_based_on_response!(response, object_identifier = nil)
           exception_class = case response.status
-                            when 404
-                              NotFoundResponse
+                            when 400
+                              BadRequestError
                             when 401
                               UnauthorizedResponse
+                            when 404
+                              NotFoundResponse
                             when 409
                               ConflictResponse
                             else

--- a/spec/dor/services/client/objects_spec.rb
+++ b/spec/dor/services/client/objects_spec.rb
@@ -47,22 +47,31 @@ RSpec.describe Dor::Services::Client::Objects do
     end
 
     context 'when API request fails' do
-      context 'when an unexpected response' do
+      context 'when Conflict (409) response' do
         let(:status) { [409, 'object already exists'] }
         let(:body) { nil }
 
-        it 'raises an error' do
+        it 'raises ConflictResponse error' do
           expect { client.register(params: model) }.to raise_error(Dor::Services::Client::ConflictResponse,
                                                                    "object already exists: 409 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY})")
         end
       end
 
-      context 'when an unauthorized response' do
+      context 'when Unauthorized (401) response' do
         let(:status) { [401, 'unauthorized'] }
         let(:body) { nil }
 
-        it 'raises an error' do
+        it 'raises UnauthorizedResponse error' do
           expect { client.register(params: model) }.to raise_error(Dor::Services::Client::UnauthorizedResponse)
+        end
+      end
+
+      context 'when Bad Request (400) response' do
+        let(:status) { [400, 'bad request'] }
+        let(:body) { 'Bad Request: 400 ({"errors":[{"status":"400","title":some reason","detail":"blah di blah blah"}]})' }
+
+        it 'raises BadRequestError error' do
+          expect { client.register(params: model) }.to raise_error(Dor::Services::Client::BadRequestError)
         end
       end
     end


### PR DESCRIPTION
## Why was this change made?

To make it easier for consumers of dor-services-client to distinguish the error for when a catkey isn't found in Symphony.

Part of https://github.com/sul-dlss/sdr-api/issues/319

## How was this change tested?

unit tests

## Which documentation and/or configurations were updated?



