### PR TITLE
add update_doi_metadata to object

### DIFF
--- a/lib/dor/services/client/object.rb
+++ b/lib/dor/services/client/object.rb
@@ -104,6 +104,18 @@ module Dor
           raise_exception_based_on_response!(resp)
         end
 
+        # Update the DOI metadata at DataCite
+        # @raise [NotFoundResponse] when the response is a 404 (object not found)
+        # @return [boolean] true on success
+        def update_doi_metadata
+          resp = connection.post do |req|
+            req.url "#{object_path}/update_doi_metadata"
+          end
+          return true if resp.success?
+
+          raise_exception_based_on_response!(resp)
+        end
+
         # Notify the external Goobi system for a new object that was registered in DOR
         # @raise [NotFoundResponse] when the response is a 404 (object not found)
         # @raise [UnexpectedResponse] when the response is not successful.

--- a/spec/dor/services/client/object_spec.rb
+++ b/spec/dor/services/client/object_spec.rb
@@ -369,6 +369,32 @@ RSpec.describe Dor::Services::Client::Object do
     end
   end
 
+  describe '#update_doi_metadata' do
+    subject(:request) { client.update_doi_metadata }
+
+    before do
+      stub_request(:post, 'https://dor-services.example.com/v1/objects/druid:bc123df4567/update_doi_metadata')
+        .to_return(status: status)
+    end
+
+    context 'when API request succeeds' do
+      let(:status) { 202 }
+
+      it 'returns true' do
+        expect(request).to be true
+      end
+    end
+
+    context 'when API request returns 404' do
+      let(:status) { [404, 'not found'] }
+
+      it 'raises a NotFoundResponse exception' do
+        expect { request }.to raise_error(Dor::Services::Client::NotFoundResponse,
+                                          "not found: 404 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY})")
+      end
+    end
+  end
+
   describe '#refresh_metadata' do
     subject(:request) { client.refresh_metadata }
 


### PR DESCRIPTION
## Why was this change made?

So we can call the DSA update_doi_metadata endpoint using this client.

Closes #227

## How was this change tested?

unit test

## Which documentation and/or configurations were updated?



