### PR TITLE
Provide a mechanism for returning the error from the server

### DIFF
--- a/lib/dor/services/client/versioned_service.rb
+++ b/lib/dor/services/client/versioned_service.rb
@@ -33,8 +33,8 @@ module Dor
                             else
                               UnexpectedResponse
                             end
-          raise exception_class,
-                ResponseErrorFormatter.format(response: response, object_identifier: object_identifier)
+
+          raise exception_class.new(response, object_identifier)
         end
         # rubocop:enable Metrics/MethodLength
       end

--- a/spec/dor/services/client/administrative_tags_spec.rb
+++ b/spec/dor/services/client/administrative_tags_spec.rb
@@ -86,6 +86,29 @@ RSpec.describe Dor::Services::Client::AdministrativeTags do
                                           "something is amiss: 500 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY}) for #{druid}")
       end
     end
+
+    context 'when API returns an request error' do
+      before do
+        stub_request(:post, "https://dor-services.example.com/v1/objects/#{druid}/administrative_tags")
+          .to_return(status: [400, 'bad request'],
+                     headers: { 'Content-Type' => 'application/vnd.api+json' },
+                     body: '{
+              "errors": [
+                {
+                  "status": "400",
+                  "title":  "Invalid Attribute",
+                  "detail": "Tag must have at least one colin."
+                }
+              ]
+            }')
+      end
+
+      it 'raises an error' do
+        request
+      rescue Dor::Services::Client::UnexpectedResponse => e
+        expect(e.json.dig('errors', 0, 'title')).to eq 'Invalid Attribute'
+      end
+    end
   end
 
   describe '#replace' do


### PR DESCRIPTION
## Why was this change made?
So the consumer can decipher the error without having to parse the text message.

Ref https://github.com/sul-dlss/argo/issues/2813


## How was this change tested?



## Which documentation and/or configurations were updated?



