### PR TITLE
Remove unused moab-versioning dependency

### DIFF
--- a/dor-services-client.gemspec
+++ b/dor-services-client.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'cocina-models', '~> 0.62.0' # leave pinned to patch level until cocina-models hits 1.0
   spec.add_dependency 'deprecation', '>= 0'
   spec.add_dependency 'faraday', '>= 0.15', '< 2'
-  spec.add_dependency 'moab-versioning', '~> 4.0'
   spec.add_dependency 'zeitwerk', '~> 2.1'
 
   spec.add_development_dependency 'bundler'

--- a/lib/dor/services/client/marcxml.rb
+++ b/lib/dor/services/client/marcxml.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'nokogiri'
-
 module Dor
   module Services
     class Client


### PR DESCRIPTION
## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?



