### PR TITLE
add created_at metadata to object; switch metadata structure from hash to object

### DIFF
--- a/lib/dor/services/client/object.rb
+++ b/lib/dor/services/client/object.rb
@@ -50,8 +50,8 @@ module Dor
         # Retrieves the Cocina model and response metadata
         # @raise [NotFoundResponse] when the response is a 404 (object not found)
         # @raise [UnexpectedResponse] when the response is not successful.
-        # @return [Array<Cocina::Models::DRO,Cocina::Models::Collection,Cocina::Models::AdminPolicy,Hash>] a tuple where
-        #          the first is the model and the second is a hash of metadata
+        # @return [Array<Cocina::Models::DRO,Cocina::Models::Collection,Cocina::Models::AdminPolicy,ObjectMetadata>] a tuple where
+        #          the first is the model and the second is a ObjectMetadata object
         def find_with_metadata
           resp = connection.get do |req|
             req.url object_path
@@ -61,7 +61,7 @@ module Dor
           model = Cocina::Models.build(JSON.parse(resp.body))
 
           # Don't use #slice here as Faraday will downcase the keys.
-          metadata = { 'Last-Modified' => resp.headers['Last-Modified'] }
+          metadata = ObjectMetadata.new(updated_at: resp.headers['Last-Modified'], created_at: resp.headers['X-Created-At'])
           [model, metadata]
         end
 

--- a/lib/dor/services/client/object_metadata.rb
+++ b/lib/dor/services/client/object_metadata.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'deprecation'
+
+module Dor
+  module Services
+    class Client
+      # An object representing metadata about the cocina object returned by the object show method
+      class ObjectMetadata
+        extend Deprecation
+
+        attr_reader :created_at, :updated_at
+
+        def initialize(created_at:, updated_at:)
+          @created_at = created_at
+          @updated_at = updated_at
+        end
+
+        def [](key)
+          case key
+          when 'Last-Modified'
+            updated_at
+          when 'X-Created-At'
+            created_at
+          else
+            raise KeyError, 'Unknown key'
+          end
+        end
+        deprecation_deprecate(:[] => 'Hash accessor is no longer used, use object accessor instead')
+      end
+    end
+  end
+end

--- a/spec/dor/services/client/object_spec.rb
+++ b/spec/dor/services/client/object_spec.rb
@@ -151,6 +151,7 @@ RSpec.describe Dor::Services::Client::Object do
         .to_return(status: status,
                    headers: {
                      'Last-Modified' => 'Wed, 03 Mar 2021 18:58:00 GMT',
+                     'X-Created-At' => 'Wed, 01 Jan 2021 12:58:00 GMT',
                      'X-Served-By' => 'Awesome webserver'
                    },
                    body: json)
@@ -182,7 +183,9 @@ RSpec.describe Dor::Services::Client::Object do
 
       it 'returns the cocina model' do
         expect(response.first.externalIdentifier).to eq 'druid:bc123df4567'
-        expect(response[1]).to eq('Last-Modified' => 'Wed, 03 Mar 2021 18:58:00 GMT')
+        metadata = response[1]
+        expect(metadata.updated_at).to eq('Wed, 03 Mar 2021 18:58:00 GMT')
+        expect(metadata.created_at).to eq('Wed, 01 Jan 2021 12:58:00 GMT')
       end
     end
   end

--- a/spec/dor/services/client/object_spec.rb
+++ b/spec/dor/services/client/object_spec.rb
@@ -181,12 +181,18 @@ RSpec.describe Dor::Services::Client::Object do
 
       let(:status) { 200 }
 
+      # rubocop:disable RSpec/ExampleLength
       it 'returns the cocina model' do
         expect(response.first.externalIdentifier).to eq 'druid:bc123df4567'
         metadata = response[1]
         expect(metadata.updated_at).to eq('Wed, 03 Mar 2021 18:58:00 GMT')
         expect(metadata.created_at).to eq('Wed, 01 Jan 2021 12:58:00 GMT')
+        allow(Deprecation).to receive(:warn)
+        expect(metadata['Last-Modified']).to eq('Wed, 03 Mar 2021 18:58:00 GMT')
+        expect(metadata['X-Created-At']).to eq('Wed, 01 Jan 2021 12:58:00 GMT')
+        expect { metadata['X-Powered-By'] }.to raise_error(KeyError)
       end
+      # rubocop:enable RSpec/ExampleLength
     end
   end
 


### PR DESCRIPTION
## Why was this change made?

We have a new created at date returned in the header from dor-services-app, this needs to be added to the client.  See https://github.com/sul-dlss/dor-services-app/pull/3198/files

We also switched the return structure from a hash to an object, but allowed hash access.

## How was this change tested?

Update tests


## Which documentation and/or configurations were updated?



