### PR TITLE
Send and receive etags to do optimistic locking

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,9 @@ Metrics/BlockLength:
     - 'dor-services-client.gemspec'
     - 'spec/**/*'
 
+RSpec/MultipleMemoizedHelpers:
+  Max: 10
+
 Gemspec/DateAssignment: # (new in 1.10)
   Enabled: true
 Layout/SpaceBeforeBrackets: # (new in 1.7)

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -46,12 +46,6 @@ RSpec/MultipleExpectations:
     - 'spec/dor/services/client/object_spec.rb'
     - 'spec/dor/services/client/response_error_formatter_spec.rb'
 
-# Offense count: 7
-# Configuration parameters: AllowSubject, Max.
-RSpec/MultipleMemoizedHelpers:
-  Exclude:
-    - 'spec/dor/services/client/objects_spec.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 RSpec/MultipleSubjects:

--- a/lib/dor/services/client.rb
+++ b/lib/dor/services/client.rb
@@ -46,6 +46,10 @@ module Dor
       # Error that is raised when the remote server returns a 409 Conflict
       class ConflictResponse < UnexpectedResponse; end
 
+      # Error that is raised when the remote server returns a 412 Precondition Failed.
+      # This occurs when you sent an etag with If-Match, but the etag didn't match the latest version
+      class PreconditionFailedResponse < UnexpectedResponse; end
+
       # Error that is raised when the remote server returns a 400 Bad Request; apps should not retry the request
       class BadRequestError < UnexpectedResponse; end
 

--- a/lib/dor/services/client/mutate.rb
+++ b/lib/dor/services/client/mutate.rb
@@ -27,15 +27,18 @@ module Dor
 
         # Updates the object
         # @param [Cocina::Models::DRO,Cocina::Models::Collection,Cocina::Models::AdminPolicy] params model object
+        # @param [String] etag if provided, send this via an If-Match header. The server will use this to know if we've started with the latest version.
         # @raise [NotFoundResponse] when the response is a 404 (object not found)
         # @raise [UnexpectedResponse] when the response is not successful.
         # @return [Cocina::Models::DRO,Cocina::Models::Collection,Cocina::Models::AdminPolicy] the returned model
-        def update(params:)
+        # rubocop:disable Metrics/AbcSize
+        def update(params:, etag: nil)
           resp = connection.patch do |req|
             req.url object_path
             req.headers['Content-Type'] = 'application/json'
             # asking the service to return JSON (else it'll be plain text)
             req.headers['Accept'] = 'application/json'
+            req.headers['If-Match'] = etag if etag
             req.body = params.to_json
           end
 
@@ -43,6 +46,7 @@ module Dor
 
           Cocina::Models.build(JSON.parse(resp.body))
         end
+        # rubocop:enable Metrics/AbcSize
 
         # Pull in metadata from Symphony and updates descriptive metadata
         # @raise [NotFoundResponse] when the response is a 404 (object not found)

--- a/lib/dor/services/client/object.rb
+++ b/lib/dor/services/client/object.rb
@@ -64,7 +64,9 @@ module Dor
           model = Cocina::Models.build(JSON.parse(resp.body))
 
           # Don't use #slice here as Faraday will downcase the keys.
-          metadata = ObjectMetadata.new(updated_at: resp.headers['Last-Modified'], created_at: resp.headers['X-Created-At'])
+          metadata = ObjectMetadata.new(updated_at: resp.headers['Last-Modified'],
+                                        created_at: resp.headers['X-Created-At'],
+                                        etag: resp.headers['ETag'])
           [model, metadata]
         end
 

--- a/lib/dor/services/client/object_metadata.rb
+++ b/lib/dor/services/client/object_metadata.rb
@@ -9,11 +9,12 @@ module Dor
       class ObjectMetadata
         extend Deprecation
 
-        attr_reader :created_at, :updated_at
+        attr_reader :created_at, :updated_at, :etag
 
-        def initialize(created_at:, updated_at:)
+        def initialize(created_at:, updated_at:, etag: nil)
           @created_at = created_at
           @updated_at = updated_at
+          @etag = etag
         end
 
         def [](key)

--- a/lib/dor/services/client/versioned_service.rb
+++ b/lib/dor/services/client/versioned_service.rb
@@ -30,6 +30,8 @@ module Dor
                               NotFoundResponse
                             when 409
                               ConflictResponse
+                            when 412
+                              PreconditionFailedResponse
                             else
                               UnexpectedResponse
                             end


### PR DESCRIPTION
## Why was this change made? 🤔

Ref https://github.com/sul-dlss/dor-services-app/pull/3664

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



