### PR TITLE
Updates to cocina-models 0.68

### DIFF
--- a/dor-services-client.gemspec
+++ b/dor-services-client.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.7', '< 4' # dor-services-app needs 2.7 due to fedora3
 
   spec.add_dependency 'activesupport', '>= 4.2', '< 8'
-  spec.add_dependency 'cocina-models', '~> 0.67.1' # leave pinned to patch level until cocina-models hits 1.0
+  spec.add_dependency 'cocina-models', '~> 0.68.0' # leave pinned to patch level until cocina-models hits 1.0
   spec.add_dependency 'deprecation', '>= 0'
   spec.add_dependency 'faraday', '~> 2.0'
   spec.add_dependency 'faraday-retry'

--- a/spec/dor/services/client/collections_spec.rb
+++ b/spec/dor/services/client/collections_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Dor::Services::Client::Collections do
           {
             "collections":[{
               "externalIdentifier":"druid:bc123df4567",
-              "type":"#{Cocina::Models::Vocab.collection}",
+              "type":"#{Cocina::Models::ObjectType.collection}",
               "label":"my collection",
               "version":1,
               "description":{

--- a/spec/dor/services/client/object_spec.rb
+++ b/spec/dor/services/client/object_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Dor::Services::Client::Object do
         <<~JSON
           {
             "externalIdentifier":"druid:bc123df4567",
-            "type":"#{Cocina::Models::Vocab.book}",
+            "type":"#{Cocina::Models::ObjectType.book}",
             "label":"my item",
             "version":1,
             "administrative":{
@@ -121,7 +121,7 @@ RSpec.describe Dor::Services::Client::Object do
         <<~JSON
           {
             "externalIdentifier":"druid:bc123df4567",
-            "type":"#{Cocina::Models::Vocab.collection}",
+            "type":"#{Cocina::Models::ObjectType.collection}",
             "label":"my item",
             "version":1,
             "description":{
@@ -162,7 +162,7 @@ RSpec.describe Dor::Services::Client::Object do
         <<~JSON
           {
             "externalIdentifier":"druid:bc123df4567",
-            "type":"#{Cocina::Models::Vocab.book}",
+            "type":"#{Cocina::Models::ObjectType.book}",
             "label":"my item",
             "version":1,
             "administrative":{
@@ -216,7 +216,7 @@ RSpec.describe Dor::Services::Client::Object do
         <<~JSON
           {
             "externalIdentifier":"druid:bc123df4567",
-            "type":"#{Cocina::Models::Vocab.book}",
+            "type":"#{Cocina::Models::ObjectType.book}",
             "label":"my item",
             "version":1,
             "administrative":{
@@ -228,7 +228,7 @@ RSpec.describe Dor::Services::Client::Object do
                 { "value": "hey!", "type": "primary" }
               ]
             },
-            "access":{ "access": "dark", "download": "none" }
+            "access":{ "view": "dark", "download": "none" }
           }
         JSON
       end

--- a/spec/dor/services/client/objects_spec.rb
+++ b/spec/dor/services/client/objects_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Dor::Services::Client::Objects do
 
   let(:connection) { Dor::Services::Client.instance.send(:connection) }
   let(:model) { Cocina::Models::RequestDRO.new(properties) }
-  let(:item_type) { Cocina::Models::Vocab.object }
+  let(:item_type) { Cocina::Models::ObjectType.object }
   let(:properties) do
     {
       type: item_type,


### PR DESCRIPTION
## Why was this change made? 🤔

Updates cocina-models to 0.68.0 and updates tests.

## How was this change tested? 🤨
running tests

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



