### PR TITLE
Send and receive etags to do optimistic locking

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,9 @@ Metrics/BlockLength:
     - 'dor-services-client.gemspec'
     - 'spec/**/*'
 
+RSpec/MultipleMemoizedHelpers:
+  Max: 10
+
 Gemspec/DateAssignment: # (new in 1.10)
   Enabled: true
 Layout/SpaceBeforeBrackets: # (new in 1.7)

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -46,12 +46,6 @@ RSpec/MultipleExpectations:
     - 'spec/dor/services/client/object_spec.rb'
     - 'spec/dor/services/client/response_error_formatter_spec.rb'
 
-# Offense count: 7
-# Configuration parameters: AllowSubject, Max.
-RSpec/MultipleMemoizedHelpers:
-  Exclude:
-    - 'spec/dor/services/client/objects_spec.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 RSpec/MultipleSubjects:

--- a/lib/dor/services/client.rb
+++ b/lib/dor/services/client.rb
@@ -46,6 +46,10 @@ module Dor
       # Error that is raised when the remote server returns a 409 Conflict
       class ConflictResponse < UnexpectedResponse; end
 
+      # Error that is raised when the remote server returns a 412 Precondition Failed.
+      # This occurs when you sent an etag with If-Match, but the etag didn't match the latest version
+      class PreconditionFailedResponse < UnexpectedResponse; end
+
       # Error that is raised when the remote server returns a 400 Bad Request; apps should not retry the request
       class BadRequestError < UnexpectedResponse; end
 

--- a/lib/dor/services/client/object_metadata.rb
+++ b/lib/dor/services/client/object_metadata.rb
@@ -9,11 +9,12 @@ module Dor
       class ObjectMetadata
         extend Deprecation
 
-        attr_reader :created_at, :updated_at
+        attr_reader :created_at, :updated_at, :etag
 
-        def initialize(created_at:, updated_at:)
+        def initialize(created_at:, updated_at:, etag: nil)
           @created_at = created_at
           @updated_at = updated_at
+          @etag = etag
         end
 
         def [](key)

--- a/lib/dor/services/client/objects.rb
+++ b/lib/dor/services/client/objects.rb
@@ -12,20 +12,6 @@ module Dor
         # @param assign_doi [Boolean]
         # @return [Cocina::Models::RequestDRO,Cocina::Models::RequestCollection,Cocina::Models::RequestAPO] the returned model
         def register(params:, assign_doi: false)
-          json_str = register_response(params: params, assign_doi: assign_doi)
-          json = JSON.parse(json_str)
-
-          Cocina::Models.build(json)
-        end
-
-        private
-
-        # make the registration request to the server
-        # @param params [Hash] optional params (see dor-services-app)
-        # @param assign_doi [Boolean]
-        # @raise [UnexpectedResponse] on an unsuccessful response from the server
-        # @return [String] the raw JSON from the server
-        def register_response(params:, assign_doi:)
           resp = connection.post do |req|
             req.url "#{api_version}/objects"
             req.headers['Content-Type'] = 'application/json'
@@ -34,9 +20,10 @@ module Dor
             req.params[:assign_doi] = true if assign_doi
             req.body = params.to_json
           end
-          return resp.body if resp.success?
 
-          raise_exception_based_on_response!(resp)
+          raise_exception_based_on_response!(resp) unless resp.success?
+
+          build_cocina_from_response(resp)
         end
       end
     end

--- a/lib/dor/services/client/versioned_service.rb
+++ b/lib/dor/services/client/versioned_service.rb
@@ -30,6 +30,8 @@ module Dor
                               NotFoundResponse
                             when 409
                               ConflictResponse
+                            when 412
+                              PreconditionFailedResponse
                             else
                               UnexpectedResponse
                             end
@@ -37,6 +39,20 @@ module Dor
                 ResponseErrorFormatter.format(response: response, object_identifier: object_identifier)
         end
         # rubocop:enable Metrics/MethodLength
+
+        def build_cocina_from_response(response)
+          cocina_object = Cocina::Models.build(JSON.parse(response.body))
+          Cocina::Models.with_metadata(cocina_object, response.headers['ETag'], created: date_from_header(response, 'X-Created-At'),
+                                                                                modified: date_from_header(response, 'Last-Modified'))
+        end
+
+        def build_json_from_cocina(cocina_object)
+          Cocina::Models.without_metadata(cocina_object).to_json
+        end
+
+        def date_from_header(response, key)
+          response.headers[key]&.to_datetime
+        end
       end
     end
   end

--- a/spec/dor/services/client/objects_spec.rb
+++ b/spec/dor/services/client/objects_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Dor::Services::Client::Objects do
   end
 
   describe '#register' do
-    let(:status) { 200 }
+    let(:status) { 201 }
     let(:body) do
       Cocina::Models::DRO.new(model.to_h.merge(externalIdentifier: 'druid:bc123df4567',
                                                access: {}, description: description_props)).to_json
@@ -42,12 +42,19 @@ RSpec.describe Dor::Services::Client::Objects do
           body: expected_request,
           headers: { 'Content-Type' => 'application/json', 'Accept' => 'application/json' }
         )
-        .to_return(status: status, body: body)
+        .to_return(status: status,
+                   body: body,
+                   headers: {
+                     'Last-Modified' => 'Wed, 04 Mar 2021 18:58:00 GMT',
+                     'X-Created-At' => 'Wed, 02 Jan 2021 12:58:00 GMT',
+                     'X-Served-By' => 'Awesome webserver',
+                     'ETag' => 'W/"e541d8cd98f00b204e9800998ecf8427f"'
+                   })
     end
 
     context 'when API request succeeds with a cocina model' do
       it 'posts params as json' do
-        expect(client.register(params: model)).to be_kind_of Cocina::Models::DRO
+        expect(client.register(params: model)).to be_kind_of Cocina::Models::DROWithMetadata
       end
     end
 


### PR DESCRIPTION
## Why was this change made? 🤔
Support optimistic locking, so that DSA client apps don't accidentally overwrite when performing multiple saves.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

