### PR TITLE
Parse the JSON-API errors and give access to them

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,9 @@ Metrics/BlockLength:
 RSpec/MultipleMemoizedHelpers:
   Max: 10
 
+RSpec/ExampleLength:
+  Max: 10
+
 Gemspec/DateAssignment: # (new in 1.10)
   Enabled: true
 Layout/SpaceBeforeBrackets: # (new in 1.7)

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -25,12 +25,6 @@ RSpec/AnyInstance:
     - 'spec/dor/services/client/metadata_spec.rb'
     - 'spec/dor/services/client/object_version_spec.rb'
 
-# Offense count: 1
-# Configuration parameters: Max, CountAsOne.
-RSpec/ExampleLength:
-  Exclude:
-    - 'spec/dor/services/client/metadata_spec.rb'
-
 # Offense count: 6
 RSpec/IdenticalEqualityAssertion:
   Exclude:

--- a/lib/dor/services/client.rb
+++ b/lib/dor/services/client.rb
@@ -38,7 +38,26 @@ module Dor
 
       # Error that is raised when the remote server returns some unexpected response
       # this could be any 4xx or 5xx status (except the ones that are direct children of the Error class above)
-      class UnexpectedResponse < Error; end
+      class UnexpectedResponse < Error
+        # @param [Faraday::Response] response
+        # @param [String] object_identifier (nil)
+        # @param [Hash<String,Object>] errors (nil) the JSON-API errors object
+        # rubocop:disable Lint/MissingSuper
+        def initialize(response:, object_identifier: nil, errors: nil)
+          @response = response
+          @object_identifier = object_identifier
+          @errors = errors
+        end
+        # rubocop:enable Lint/MissingSuper
+
+        attr_accessor :errors
+
+        def to_s
+          return errors.map { |e| "#{e['title']} (#{e['detail']})" }.join(', ') if errors.present?
+
+          ResponseErrorFormatter.format(response: @response, object_identifier: @object_identifier)
+        end
+      end
 
       # Error that is raised when the remote server returns a 401 Unauthorized
       class UnauthorizedResponse < UnexpectedResponse; end

--- a/lib/dor/services/client/marcxml.rb
+++ b/lib/dor/services/client/marcxml.rb
@@ -20,9 +20,9 @@ module Dor
 
           # This method needs its own exception handling logic due to how the endpoint service (SearchWorks) operates
           # raise a NotFoundResponse because the resource being requested was not found in the ILS (via dor-services-app)
-          raise NotFoundResponse, ResponseErrorFormatter.format(response: resp) if resp.success? && resp.body.blank?
+          raise NotFoundResponse.new(response: resp) if resp.success? && resp.body.blank?
 
-          raise UnexpectedResponse, ResponseErrorFormatter.format(response: resp)
+          raise UnexpectedResponse.new(response: resp)
         end
 
         # Gets MARCXML corresponding to a barcode or catkey
@@ -45,9 +45,9 @@ module Dor
           # DOR Services App does not respond with a 404 when no match in Symphony.
           # Rather, it responds with a 500 containing "Record not found in Symphony" in the body.
           # raise a NotFoundResponse because the resource being requested was not found in the ILS (via dor-services-app)
-          raise NotFoundResponse, ResponseErrorFormatter.format(response: resp) if !resp.success? && resp.body.match?(/Record not found in Symphony/)
+          raise NotFoundResponse.new(response: resp) if !resp.success? && resp.body.match?(/Record not found in Symphony/)
 
-          raise UnexpectedResponse, ResponseErrorFormatter.format(response: resp) unless resp.success?
+          raise UnexpectedResponse.new(response: resp) unless resp.success?
 
           resp.body
         end

--- a/spec/dor/services/client/administrative_tags_spec.rb
+++ b/spec/dor/services/client/administrative_tags_spec.rb
@@ -31,8 +31,7 @@ RSpec.describe Dor::Services::Client::AdministrativeTags do
       end
 
       it 'raises an error' do
-        expect { request }.to raise_error(Dor::Services::Client::NotFoundResponse,
-                                          "object not found: 404 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY}) for #{druid}")
+        expect { request }.to raise_error(Dor::Services::Client::NotFoundResponse)
       end
     end
 
@@ -43,8 +42,7 @@ RSpec.describe Dor::Services::Client::AdministrativeTags do
       end
 
       it 'raises an error' do
-        expect { request }.to raise_error(Dor::Services::Client::UnexpectedResponse,
-                                          "something is amiss: 500 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY}) for #{druid}")
+        expect { request }.to raise_error(Dor::Services::Client::UnexpectedResponse)
       end
     end
   end
@@ -70,8 +68,7 @@ RSpec.describe Dor::Services::Client::AdministrativeTags do
       end
 
       it 'raises an error' do
-        expect { request }.to raise_error(Dor::Services::Client::UnexpectedResponse,
-                                          "conflict: 409 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY}) for #{druid}")
+        expect { request }.to raise_error(Dor::Services::Client::UnexpectedResponse)
       end
     end
 
@@ -82,8 +79,7 @@ RSpec.describe Dor::Services::Client::AdministrativeTags do
       end
 
       it 'raises an error' do
-        expect { request }.to raise_error(Dor::Services::Client::UnexpectedResponse,
-                                          "something is amiss: 500 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY}) for #{druid}")
+        expect { request }.to raise_error(Dor::Services::Client::UnexpectedResponse)
       end
     end
   end
@@ -109,8 +105,7 @@ RSpec.describe Dor::Services::Client::AdministrativeTags do
       end
 
       it 'raises an error' do
-        expect { request }.to raise_error(Dor::Services::Client::UnexpectedResponse,
-                                          "conflict: 409 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY}) for #{druid}")
+        expect { request }.to raise_error(Dor::Services::Client::UnexpectedResponse)
       end
     end
 
@@ -121,8 +116,7 @@ RSpec.describe Dor::Services::Client::AdministrativeTags do
       end
 
       it 'raises an error' do
-        expect { request }.to raise_error(Dor::Services::Client::UnexpectedResponse,
-                                          "something is amiss: 500 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY}) for #{druid}")
+        expect { request }.to raise_error(Dor::Services::Client::UnexpectedResponse)
       end
     end
   end
@@ -151,8 +145,7 @@ RSpec.describe Dor::Services::Client::AdministrativeTags do
       end
 
       it 'raises an error' do
-        expect { request }.to raise_error(Dor::Services::Client::NotFoundResponse,
-                                          "object not found: 404 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY}) for #{druid}")
+        expect { request }.to raise_error(Dor::Services::Client::NotFoundResponse)
       end
     end
 
@@ -163,8 +156,7 @@ RSpec.describe Dor::Services::Client::AdministrativeTags do
       end
 
       it 'raises an error' do
-        expect { request }.to raise_error(Dor::Services::Client::UnexpectedResponse,
-                                          "conflict: 409 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY}) for #{druid}")
+        expect { request }.to raise_error(Dor::Services::Client::UnexpectedResponse)
       end
     end
 
@@ -175,8 +167,7 @@ RSpec.describe Dor::Services::Client::AdministrativeTags do
       end
 
       it 'raises an error' do
-        expect { request }.to raise_error(Dor::Services::Client::UnexpectedResponse,
-                                          "something is amiss: 500 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY}) for #{druid}")
+        expect { request }.to raise_error(Dor::Services::Client::UnexpectedResponse)
       end
     end
   end
@@ -204,8 +195,7 @@ RSpec.describe Dor::Services::Client::AdministrativeTags do
       end
 
       it 'raises an error' do
-        expect { request }.to raise_error(Dor::Services::Client::NotFoundResponse,
-                                          "object not found: 404 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY}) for #{druid}")
+        expect { request }.to raise_error(Dor::Services::Client::NotFoundResponse)
       end
     end
 

--- a/spec/dor/services/client/background_job_results_spec.rb
+++ b/spec/dor/services/client/background_job_results_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Dor::Services::Client::BackgroundJobResults do
 
     context 'when API request fails with 400' do
       let(:status) { [400, 'bad request'] }
-      let(:body) { '{"errors":["error message here"]}' }
+      let(:body) { '{"errors":[{"title":"error message here"}]}' }
 
       it 'raises an error' do
         expect { client.show(job_id: 123) }.to raise_error(Dor::Services::Client::UnexpectedResponse,
@@ -65,11 +65,10 @@ RSpec.describe Dor::Services::Client::BackgroundJobResults do
 
     context 'when API request fails with 404' do
       let(:status) { [404, 'not found'] }
-      let(:body) { '{"errors":["error message here"]}' }
+      let(:body) { '{"errors":[{"title":"error message here"}]}' }
 
       it 'raises an error' do
-        expect { client.show(job_id: 123) }.to raise_error(Dor::Services::Client::NotFoundResponse,
-                                                           "not found: 404 (#{body})")
+        expect { client.show(job_id: 123) }.to raise_error(Dor::Services::Client::NotFoundResponse)
       end
     end
   end

--- a/spec/dor/services/client/metadata_spec.rb
+++ b/spec/dor/services/client/metadata_spec.rb
@@ -233,10 +233,7 @@ RSpec.describe Dor::Services::Client::Metadata do
         let(:status) { [404, 'not found'] }
 
         it 'raises an error' do
-          expect { client.legacy_update(params) }.to(
-            raise_error(Dor::Services::Client::NotFoundResponse,
-                        "not found: 404 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY}) for druid:1234")
-          )
+          expect { client.legacy_update(params) }.to raise_error(Dor::Services::Client::NotFoundResponse)
         end
       end
     end
@@ -265,10 +262,7 @@ RSpec.describe Dor::Services::Client::Metadata do
         let(:status) { [404, 'not found'] }
 
         it 'raises an error' do
-          expect { client.legacy_update(params) }.to(
-            raise_error(Dor::Services::Client::NotFoundResponse,
-                        "not found: 404 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY}) for druid:1234")
-          )
+          expect { client.legacy_update(params) }.to raise_error(Dor::Services::Client::NotFoundResponse)
         end
       end
     end

--- a/spec/dor/services/client/object_version_spec.rb
+++ b/spec/dor/services/client/object_version_spec.rb
@@ -32,8 +32,7 @@ RSpec.describe Dor::Services::Client::ObjectVersion do
       let(:body) { '' }
 
       it 'raises a NotFoundResponse exception' do
-        expect { request }.to raise_error(Dor::Services::Client::NotFoundResponse,
-                                          "not found: 404 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY})")
+        expect { request }.to raise_error(Dor::Services::Client::NotFoundResponse)
       end
     end
 
@@ -173,8 +172,7 @@ RSpec.describe Dor::Services::Client::ObjectVersion do
       let(:body) { '' }
 
       it 'raises a NotFoundResponse exception' do
-        expect { request }.to raise_error(Dor::Services::Client::NotFoundResponse,
-                                          "not found: 404 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY})")
+        expect { request }.to raise_error(Dor::Services::Client::NotFoundResponse)
       end
     end
 
@@ -232,8 +230,7 @@ RSpec.describe Dor::Services::Client::ObjectVersion do
       let(:body) { '' }
 
       it 'raises a NotFoundResponse exception' do
-        expect { request }.to raise_error(Dor::Services::Client::NotFoundResponse,
-                                          "not found: 404 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY})")
+        expect { request }.to raise_error(Dor::Services::Client::NotFoundResponse)
       end
     end
 
@@ -281,8 +278,7 @@ RSpec.describe Dor::Services::Client::ObjectVersion do
       let(:body) { '' }
 
       it 'raises a NotFoundResponse exception' do
-        expect { request }.to raise_error(Dor::Services::Client::NotFoundResponse,
-                                          "not found: 404 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY})")
+        expect { request }.to raise_error(Dor::Services::Client::NotFoundResponse)
       end
     end
 


### PR DESCRIPTION
## Why was this change made? 🤔

This should allow us to make only the relevant info available to https://github.com/sul-dlss/argo/issues/3523 so we can show more of the error without overflowing the cookie.

## How was this change tested? 🤨
test suite
