### PR TITLE
Use an ArgumentError when the method is called with a bad argument

### DIFF
--- a/lib/dor/services/client/mutate.rb
+++ b/lib/dor/services/client/mutate.rb
@@ -35,7 +35,7 @@ module Dor
         # rubocop:disable Metrics/AbcSize
         def update(params:, skip_lock: false)
           # Raised if Cocina::Models::*WithMetadata not provided.
-          raise BadRequestError, 'ETag not provided.' unless skip_lock || params.respond_to?(:lock)
+          raise ArgumentError, 'ETag not provided.' unless skip_lock || params.respond_to?(:lock)
 
           resp = connection.patch do |req|
             req.url object_path

--- a/spec/dor/services/client/object_spec.rb
+++ b/spec/dor/services/client/object_spec.rb
@@ -284,7 +284,7 @@ RSpec.describe Dor::Services::Client::Object do
 
     context 'when missing lock' do
       it 'raises' do
-        expect { client.update(params: dro) }.to raise_error(Dor::Services::Client::BadRequestError)
+        expect { client.update(params: dro) }.to raise_error(ArgumentError)
       end
     end
 


### PR DESCRIPTION


## Why was this change made? 🤔
The BadRequestError is used when DSA tells us you have sent a bad request.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



