### PR TITLE
Use the correct JSON API mime-type

### DIFF
--- a/lib/dor/services/client/versioned_service.rb
+++ b/lib/dor/services/client/versioned_service.rb
@@ -13,6 +13,8 @@ module Dor
           412 => PreconditionFailedResponse
         }.freeze
 
+        JSON_API_MIME_TYPE = 'application/vnd.api+json'
+
         def initialize(connection:, version:)
           @connection = connection
           @api_version = version
@@ -28,7 +30,7 @@ module Dor
         attr_reader :connection, :api_version
 
         def raise_exception_based_on_response!(response, object_identifier = nil)
-          data = if response.headers['content-type'] == 'application/json'
+          data = if response.headers.fetch('content-type', '').start_with?(JSON_API_MIME_TYPE)
                    JSON.parse(response.body)
                  else
                    {}

--- a/spec/dor/services/client/object_spec.rb
+++ b/spec/dor/services/client/object_spec.rb
@@ -480,7 +480,7 @@ RSpec.describe Dor::Services::Client::Object do
 
     context 'when API request fails' do
       let(:status) { [422, 'something wrong'] }
-      let(:headers) { { 'content-type' => 'application/json' } }
+      let(:headers) { { 'content-type' => 'application/vnd.api+json' } }
       let(:body) do
         <<~JSON
           {"errors":


### PR DESCRIPTION
## Why was this change made? 🤔
The responses were returning "application/vnd.api+json" so they weren't being parsed.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



