### PR TITLE
Handle cocina model returned from version open.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ Metrics/BlockLength:
     - 'spec/**/*'
 
 RSpec/MultipleMemoizedHelpers:
-  Max: 10
+  Enabled: false
 
 RSpec/ExampleLength:
   Max: 10


### PR DESCRIPTION
## Why was this change made? 🤔
The version open endpoint now returns a cocina model instead of the version string.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



