### PR TITLE
Do not validate by default when instantiating cocina.

### DIFF
--- a/lib/dor/services/client/mutate.rb
+++ b/lib/dor/services/client/mutate.rb
@@ -28,13 +28,14 @@ module Dor
         # Updates the object
         # @param [Cocina::Models::DROWithMetadata|CollectionWithMetadata|AdminPolicyWithMetadata|DRO|Collection|AdminPolicy] params model object
         # @param [boolean] skip_lock do not provide ETag
+        # @param [boolean] validate validate the response object
         # @raise [NotFoundResponse] when the response is a 404 (object not found)
         # @raise [UnexpectedResponse] when the response is not successful.
         # @raise [BadRequestError] when ETag not provided.
         # @return [Cocina::Models::DROWithMetadata,Cocina::Models::CollectionWithMetadata,Cocina::Models::AdminPolicyWithMetadata] the returned model
         # rubocop:disable Metrics/AbcSize
         # rubocop:disable Metrics/MethodLength
-        def update(params:, skip_lock: false)
+        def update(params:, skip_lock: false, validate: false)
           raise ArgumentError, 'Cocina object not provided.' unless params.respond_to?(:externalIdentifier)
 
           # Raised if Cocina::Models::*WithMetadata not provided.
@@ -51,7 +52,7 @@ module Dor
 
           raise_exception_based_on_response!(resp) unless resp.success?
 
-          build_cocina_from_response(resp)
+          build_cocina_from_response(resp, validate: validate)
         end
         # rubocop:enable Metrics/AbcSize
         # rubocop:enable Metrics/MethodLength

--- a/lib/dor/services/client/object.rb
+++ b/lib/dor/services/client/object.rb
@@ -43,16 +43,17 @@ module Dor
         end
 
         # Retrieves the Cocina model
+        # @param [boolean] validate validate the response object
         # @raise [NotFoundResponse] when the response is a 404 (object not found)
         # @raise [UnexpectedResponse] when the response is not successful.
         # @return [Cocina::Models::DROWithMetadata,Cocina::Models::CollectionWithMetadata,Cocina::Models::AdminPolicyWithMetadata] the returned model
-        def find
+        def find(validate: false)
           resp = connection.get do |req|
             req.url object_path
           end
           raise_exception_based_on_response!(resp) unless resp.success?
 
-          build_cocina_from_response(resp)
+          build_cocina_from_response(resp, validate: validate)
         end
 
         # Get a list of the collections. (Similar to Valkyrie's find_inverse_references_by)

--- a/lib/dor/services/client/objects.rb
+++ b/lib/dor/services/client/objects.rb
@@ -10,8 +10,9 @@ module Dor
         # Creates a new object in DOR
         # @param params [Cocina::Models::RequestDRO,Cocina::Models::RequestCollection,Cocina::Models::RequestAdminPolicy]
         # @param assign_doi [Boolean]
+        # @param [boolean] validate validate the response object
         # @return [Cocina::Models::DROWithMetadata,Cocina::Models::CollectionWithMetadata,Cocina::Models::AdminPolicyWithMetadata] the returned model
-        def register(params:, assign_doi: false)
+        def register(params:, assign_doi: false, validate: false)
           resp = connection.post do |req|
             req.url "#{api_version}/objects"
             req.headers['Content-Type'] = 'application/json'
@@ -23,7 +24,7 @@ module Dor
 
           raise_exception_based_on_response!(resp) unless resp.success?
 
-          build_cocina_from_response(resp)
+          build_cocina_from_response(resp, validate: validate)
         end
       end
     end

--- a/lib/dor/services/client/versioned_service.rb
+++ b/lib/dor/services/client/versioned_service.rb
@@ -41,8 +41,8 @@ module Dor
                                     errors: data.fetch('errors', []))
         end
 
-        def build_cocina_from_response(response)
-          cocina_object = Cocina::Models.build(JSON.parse(response.body))
+        def build_cocina_from_response(response, validate: false)
+          cocina_object = Cocina::Models.build(JSON.parse(response.body), validate: validate)
           Cocina::Models.with_metadata(cocina_object, response.headers['ETag'], created: date_from_header(response, 'X-Created-At'),
                                                                                 modified: date_from_header(response, 'Last-Modified'))
         end


### PR DESCRIPTION
## Why was this change made? 🤔
DSA should provide valid cocina objects; validating is redundant and a performance drag.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



