### PR TITLE
ruby version 3.0 now in use

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ require:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.7 # dor-services-app can't be 3 due to fedora3
+  TargetRubyVersion: 3.0
   SuggestExtensions: false
 
 Metrics/BlockLength:

--- a/dor-services-client.gemspec
+++ b/dor-services-client.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.7', '< 4' # dor-services-app needs 2.7 due to fedora3
+  spec.required_ruby_version = '>= 3.0', '< 4'
 
   spec.add_dependency 'activesupport', '>= 4.2', '< 8'
   spec.add_dependency 'cocina-models', '~> 0.84.0'


### PR DESCRIPTION
## Why was this change made? 🤔

we want to be on ruby 3.0 now

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



