### PR TITLE
Revert "update cocina-models to 0.85.0" due to EMPTY parallelContributor presence

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     dor-services-client (12.8.0)
       activesupport (>= 4.2, < 8)
-      cocina-models (~> 0.85.0)
+      cocina-models (~> 0.84.0)
       deprecation
       faraday (~> 2.0)
       faraday-retry
@@ -22,7 +22,7 @@ GEM
     ast (2.4.2)
     attr_extras (6.2.5)
     byebug (11.1.3)
-    cocina-models (0.85.0)
+    cocina-models (0.84.5)
       activesupport
       deprecation
       dry-struct (~> 1.0)
@@ -99,7 +99,7 @@ GEM
     racc (1.6.0)
     rainbow (3.1.1)
     rake (13.0.6)
-    regexp_parser (2.6.0)
+    regexp_parser (2.5.0)
     rexml (3.2.5)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
@@ -169,4 +169,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.3.22
+   2.3.17

--- a/dor-services-client.gemspec
+++ b/dor-services-client.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0', '< 4'
 
   spec.add_dependency 'activesupport', '>= 4.2', '< 8'
-  spec.add_dependency 'cocina-models', '~> 0.85.0'
+  spec.add_dependency 'cocina-models', '~> 0.84.0'
   spec.add_dependency 'deprecation', '>= 0'
   spec.add_dependency 'faraday', '~> 2.0'
   spec.add_dependency 'faraday-retry'


### PR DESCRIPTION
Reverts sul-dlss/dor-services-client#304