### PR TITLE
set a timeout for long running responses

### DIFF
--- a/lib/dor/services/client.rb
+++ b/lib/dor/services/client.rb
@@ -153,6 +153,8 @@ module Dor
           #   the Faraday instance will be passed an empty block, which
           #   causes the adapter not to be set. Thus, everything breaks.
           builder.adapter Faraday.default_adapter
+          # 5 minutes read timeout for very large cocina (eg. many files) object create/update (default if none set is 60 seconds)
+          builder.options[:timeout] = 300
           builder.headers[:user_agent] = user_agent
           builder.headers[TOKEN_HEADER] = "Bearer #{token}"
           builder.request :retry, max: 4, interval: 1, backoff_factor: 2 if with_retries


### PR DESCRIPTION
## Why was this change made? 🤔

This may help with sul-dlss/common-accessioning#1005, which appears to be a timeout from DSA from a very large post of cocina data.  The default timeout if none is set may be 60 seconds (https://github.com/lostisland/faraday/issues/708).

See also https://github.com/lostisland/faraday/issues/417

Currently doing some investigation to try and understand why that particular call takes so long on DSA.
