### PR TITLE
Add folio_instance_hrid param to marcxml

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,6 +158,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-darwin-20
   x86_64-darwin-21
   x86_64-linux
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ marcxml_client.marcxml(barcode: '123456789')
 # Retrieve MARCXML for a given catkey
 marcxml_client.marcxml(catkey: '987654321')
 
+# Retrieve MARCXML for a given FOLIO instance HRID
+marcxml_client.marcxml(folio_instance_hrid: 'in000123')
+
 # For performing operations on a known, registered object
 object_client = Dor::Services::Client.object(object_identifier)
 

--- a/lib/dor/services/client.rb
+++ b/lib/dor/services/client.rb
@@ -27,7 +27,7 @@ module Dor
       # Base class for Dor::Services::Client exceptions
       class Error < StandardError; end
 
-      # Error that is raised when the ultimate remote server returns a 404 Not Found for the id in our request (e.g. for druid, barcode, catkey)
+      # Error that is raised when the ultimate remote server returns a 404 Not Found for the id in our request (e.g. druid, barcode, catkey, folio_instance_hrid)
       class NotFoundResponse < Error; end
 
       # Error that is raised when the remote server returns some unparsable response


### PR DESCRIPTION
## Why was this change made? 🤔
Resolves #333.

## How was this change tested? 🤨
Unit. Tested on Argo QA in the rails console with: 
`Dor::Services::Client.marcxml.marcxml(catkey: '6671606', folio_instance_hrid: 'a6671606')` 
`Dor::Services::Client.marcxml.marcxml(catkey: '6671606')`

and marcxml returned from Symphony as expected. 

