### PR TITLE
Remove `Metadata#public_xml` which is now dead code

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,9 +138,6 @@ object_client.metadata.dublin_core
 # Get the public descriptive XML representation
 object_client.metadata.descriptive
 
-# Get the public XML representation
-object_client.metadata.public_xml
-
 # Return the Cocina metadata
 object_client.find
 

--- a/lib/dor/services/client/metadata.rb
+++ b/lib/dor/services/client/metadata.rb
@@ -37,18 +37,6 @@ module Dor
           raise_exception_based_on_response!(resp, object_identifier)
         end
 
-        # @return [String, NilClass] The public XML representation of the object or nil if response is 404
-        # @raise [UnexpectedResponse] on an unsuccessful response from the server
-        def public_xml
-          resp = connection.get do |req|
-            req.url "#{base_path}/public_xml"
-          end
-          return resp.body if resp.success?
-          return if resp.status == 404
-
-          raise_exception_based_on_response!(resp, object_identifier)
-        end
-
         # @return [String, NilClass] the dor object's source MODS XML or nil if response is 404
         # @raise [UnexpectedResponse] on an unsuccessful response from the server
         def mods

--- a/spec/dor/services/client/metadata_spec.rb
+++ b/spec/dor/services/client/metadata_spec.rb
@@ -45,67 +45,6 @@ RSpec.describe Dor::Services::Client::Metadata do
     end
   end
 
-  describe '#public_xml' do
-    subject(:response) { client.public_xml }
-
-    before do
-      stub_request(:get, 'https://dor-services.example.com/v1/objects/druid:1234/metadata/public_xml')
-        .to_return(status: status, body: body)
-    end
-
-    context 'when the object is found' do
-      let(:status) { 200 }
-      let(:body) do
-        <<~XML
-          <publicObject id="druid:1234" published="2021-04-23T19:43:06Z" publishVersion="dor-services/9.6.2">
-            <identityMetadata/>
-            <rightsMetadata>
-              <access type="discover">
-                <machine>
-                  <none/>
-                </machine>
-              </access>
-              <access type="read">
-                <machine>
-                  <none/>
-                </machine>
-              </access>
-              <use>
-                <human type="useAndReproduction"/>
-                <human type="creativeCommons"/>
-                <machine type="creativeCommons" uri=""/>
-                <human type="openDataCommons"/>
-                <machine type="openDataCommons" uri=""/>
-              </use>
-              <copyright>
-                <human/>
-              </copyright>
-            </rightsMetadata>
-          </publicObject>
-        XML
-      end
-
-      it { is_expected.to eq body }
-    end
-
-    context 'when the object is not found' do
-      let(:status) { 404 }
-      let(:body) { '' }
-
-      it { is_expected.to be_nil }
-    end
-
-    context 'when there is a server error' do
-      let(:status) { [500, 'internal server error'] }
-      let(:body) { 'broken' }
-
-      it 'raises an error' do
-        expect { response }.to raise_error(Dor::Services::Client::UnexpectedResponse,
-                                           'internal server error: 500 (broken) for druid:1234')
-      end
-    end
-  end
-
   describe '#descriptive' do
     subject(:response) { client.descriptive }
 


### PR DESCRIPTION
## Why was this change made? 🤔

Connects to sul-dlss/infrastructure-integration-test#575

There was only one consumer of this endpoint---our integration test suite---and now this is no longer used. Public XML generation is moving out of DSA and into purl-fetcher.


## How was this change tested? 🤨

CI
