### PR TITLE
Include more exception context when HTTP connection fails

### DIFF
--- a/lib/dor/services/client/error_faraday_middleware.rb
+++ b/lib/dor/services/client/error_faraday_middleware.rb
@@ -7,8 +7,8 @@ module Dor
       class ErrorFaradayMiddleware < Faraday::Middleware
         def call(env)
           @app.call(env)
-        rescue Faraday::ConnectionFailed
-          raise ConnectionFailed, 'unable to reach dor-services-app'
+        rescue Faraday::ConnectionFailed => e
+          raise ConnectionFailed, "unable to reach dor-services-app: #{e}", e.backtrace
         end
       end
     end

--- a/spec/dor/services/client/object_version_spec.rb
+++ b/spec/dor/services/client/object_version_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Dor::Services::Client::ObjectVersion do
       let(:body) { '' }
 
       it 'raises an error' do
-        expect { request }.to raise_error(Dor::Services::Client::ConnectionFailed, 'unable to reach dor-services-app')
+        expect { request }.to raise_error(Dor::Services::Client::ConnectionFailed, 'unable to reach dor-services-app: end of file reached')
       end
     end
   end
@@ -114,7 +114,7 @@ RSpec.describe Dor::Services::Client::ObjectVersion do
       let(:body) { '' }
 
       it 'raises an error' do
-        expect { request }.to raise_error(Dor::Services::Client::ConnectionFailed, 'unable to reach dor-services-app')
+        expect { request }.to raise_error(Dor::Services::Client::ConnectionFailed, 'unable to reach dor-services-app: end of file reached')
       end
     end
   end


### PR DESCRIPTION
# Why was this change made?

This will give us a little more diagnostic information to help troubleshoot what are currently difficult-to-pinpoint exceptions, such as when dor_indexing_app cannot reach dor-services-app.

# How was this change tested?

CI
