### PR TITLE
upgrade to cocina-models 0.94.2 for auto-deployment ease

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ GEM
     base64 (0.2.0)
     bigdecimal (3.1.6)
     byebug (11.1.3)
-    cocina-models (0.94.0)
+    cocina-models (0.94.2)
       activesupport
       deprecation
       dry-struct (~> 1.0)


### PR DESCRIPTION
## Why was this change made? 🤔

A silly attempt to avoid sdr-deploy problems due to patch release differences in cocina-model versions.

## How was this change tested? 🤨

there's no change needed here; CI is adequate testing.


