### PR TITLE
send workflow context to DSA in body as json

### DIFF
--- a/lib/dor/services/client/accession.rb
+++ b/lib/dor/services/client/accession.rb
@@ -18,12 +18,16 @@ module Dor
         # @option params [String] :description set description of version change - required
         # @option params [String] :opening_user_name add opening username to the event - optional
         # @option params [String] :workflow the workflow to start - defaults to 'assemblyWF'
+        # @option params [Hash] :context the workflow context - optional
         # @return [Boolean] true on success
         # @raise [NotFoundResponse] when the response is a 404 (object not found)
         # @raise [UnexpectedResponse] when the response is not successful.
         def start(params = {})
+          body = params[:context] ? { 'context' => params[:context] }.to_json : ''
           resp = connection.post do |req|
-            req.url with_querystring(url: path, params: params)
+            req.url with_querystring(url: path, params: params.except(:context))
+            req.headers['Content-Type'] = 'application/json'
+            req.body = body
           end
           return true if resp.success?
 

--- a/spec/dor/services/client/accession_spec.rb
+++ b/spec/dor/services/client/accession_spec.rb
@@ -12,12 +12,14 @@ RSpec.describe Dor::Services::Client::Accession do
   end
 
   let(:connection) { Dor::Services::Client.instance.send(:connection) }
+  let(:headers) { { 'Authorization' => 'Bearer 123', 'Content-Type' => 'application/json' } }
+  let(:body) { '' }
 
   describe '#start' do
     context 'with no params' do
       before do
         stub_request(:post, 'https://dor-services.example.com/v1/objects/druid:1234/accession')
-          .to_return(status: status)
+          .with(body: body, headers: headers).to_return(status: status)
       end
 
       context 'when API request succeeds' do
@@ -41,7 +43,7 @@ RSpec.describe Dor::Services::Client::Accession do
     context 'with params' do
       before do
         stub_request(:post, 'https://dor-services.example.com/v1/objects/druid:1234/accession?workflow=accessionWF&opening_user_name=dude')
-          .to_return(status: status)
+          .with(body: body, headers: headers).to_return(status: status)
       end
 
       context 'when API request succeeds' do
@@ -50,6 +52,15 @@ RSpec.describe Dor::Services::Client::Accession do
 
         it 'returns true' do
           expect(client.start(params)).to be true
+        end
+
+        context 'with context' do
+          let(:body) { '{"context":{"requireOCR":true}}' }
+          let(:params) { { opening_user_name: 'dude', workflow: 'accessionWF', context: { 'requireOCR' => true } } }
+
+          it 'returns true' do
+            expect(client.start(params)).to be true
+          end
         end
       end
     end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #427 - allows us to send workflow content to DSA, which will then pass it on the workflow service.

We will use this first in pre-assembly to send workflow context, from here: https://github.com/sul-dlss/pre-assembly/blob/main/app/services/start_accession.rb#L5-L15

~~HOLD for sul-dlss/dor-services-app#4983 since we need the DSA change first for this to work~~

## How was this change tested? 🤨

New specs