### PR TITLE
Adds support for user version index endpoint.

### DIFF
--- a/lib/dor/services/client/object.rb
+++ b/lib/dor/services/client/object.rb
@@ -38,6 +38,10 @@ module Dor
           @version ||= ObjectVersion.new(**parent_params)
         end
 
+        def user_version
+          @user_version ||= UserVersion.new(**parent_params)
+        end
+
         def accession(params = {})
           @accession ||= Accession.new(**parent_params.merge(params))
         end

--- a/lib/dor/services/client/user_version.rb
+++ b/lib/dor/services/client/user_version.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Dor
+  module Services
+    class Client
+      # API calls that are about user versions
+      class UserVersion < VersionedService
+        Version = Struct.new(:version, :userVersion, keyword_init: true)
+
+        # @param object_identifier [String] the pid for the object
+        def initialize(connection:, version:, object_identifier:)
+          super(connection: connection, version: version)
+          @object_identifier = object_identifier
+        end
+
+        # @return [Array] a list of the user versions
+        # @raise [UnexpectedResponse] on an unsuccessful response from the server
+        def inventory
+          resp = connection.get do |req|
+            req.url base_path
+          end
+          raise_exception_based_on_response!(resp, object_identifier) unless resp.success?
+
+          JSON.parse(resp.body).fetch('user_versions').map { |params| Version.new(**params.symbolize_keys!) }
+        end
+
+        private
+
+        attr_reader :object_identifier
+
+        def object_path
+          "#{api_version}/objects/#{object_identifier}"
+        end
+
+        def base_path
+          "#{object_path}/user_versions"
+        end
+      end
+    end
+  end
+end

--- a/spec/dor/services/client/object_spec.rb
+++ b/spec/dor/services/client/object_spec.rb
@@ -72,6 +72,12 @@ RSpec.describe Dor::Services::Client::Object do
     end
   end
 
+  describe '#user_version' do
+    it 'returns an instance of Client::UserVersion' do
+      expect(client.user_version).to be_instance_of Dor::Services::Client::UserVersion
+    end
+  end
+
   describe '#events' do
     it 'returns an instance of Client::Events' do
       expect(client.events).to be_instance_of Dor::Services::Client::Events

--- a/spec/dor/services/client/user_version_spec.rb
+++ b/spec/dor/services/client/user_version_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+RSpec.describe Dor::Services::Client::UserVersion do
+  subject(:client) { described_class.new(connection: connection, version: 'v1', object_identifier: pid) }
+
+  before do
+    Dor::Services::Client.configure(url: 'https://dor-services.example.com', token: '123', enable_get_retries: false)
+  end
+
+  let(:connection) { Dor::Services::Client.instance.send(:connection) }
+  let(:pid) { 'druid:1234' }
+
+  describe '#inventory' do
+    subject(:request) { client.inventory }
+
+    before do
+      stub_request(:get, 'https://dor-services.example.com/v1/objects/druid:1234/user_versions')
+        .to_return(status: status, body: body)
+    end
+
+    context 'when API request succeeds' do
+      let(:status) { 200 }
+      let(:body) do
+        <<~JSON
+          {"user_versions":[
+            {"version":1,"userVersion":1},
+            {"version":3,"userVersion":2}
+          ]}
+        JSON
+      end
+
+      it 'returns the list of versions' do
+        expect(request).to eq [
+          described_class::Version.new(version: 1, userVersion: 1),
+          described_class::Version.new(version: 3, userVersion: 2)
+        ]
+      end
+    end
+
+    context 'when API request returns 404' do
+      let(:status) { [404, 'not found'] }
+      let(:body) { '' }
+
+      it 'raises a NotFoundResponse exception' do
+        expect { request }.to raise_error(Dor::Services::Client::NotFoundResponse)
+      end
+    end
+
+    context 'when API request fails' do
+      let(:status) { [401, 'unauthorized'] }
+      let(:body) { '' }
+
+      it 'raises an error' do
+        expect { request }.to raise_error(Dor::Services::Client::UnauthorizedResponse)
+      end
+    end
+
+    context 'when connection fails' do
+      before do
+        allow_any_instance_of(Faraday::Adapter::NetHttp).to receive(:call).and_raise(Faraday::ConnectionFailed.new('end of file reached')) # rubocop:disable RSpec/AnyInstance
+      end
+
+      let(:status) { 555 }
+      let(:body) { '' }
+
+      it 'raises an error' do
+        expect { request }.to raise_error(Dor::Services::Client::ConnectionFailed, 'unable to reach dor-services-app: end of file reached')
+      end
+    end
+  end
+end


### PR DESCRIPTION
closes #426

## Why was this change made? 🤔
Allow user versions to be displayed in Argo.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



