### PR TITLE
return the workspace directory created

### DIFF
--- a/lib/dor/services/client/workspace.rb
+++ b/lib/dor/services/client/workspace.rb
@@ -17,6 +17,7 @@ module Dor
         # @param metadata [Boolean] determines if the metadata directory should be created (defaults to false)
         # @raise [UnexpectedResponse] if the request is unsuccessful.
         # @return [String] the path to the directory created
+        # rubocop:disable Metrics/AbcSize
         def create(source: nil, content: false, metadata: false)
           resp = connection.post do |req|
             req.url workspace_path
@@ -28,6 +29,7 @@ module Dor
 
           raise_exception_based_on_response!(resp, object_identifier) unless resp.success?
         end
+        # rubocop:enable Metrics/AbcSize
 
         # Cleans up a workspace
         # @raise [NotFoundResponse] when the response is a 404 (object not found)

--- a/lib/dor/services/client/workspace.rb
+++ b/lib/dor/services/client/workspace.rb
@@ -12,14 +12,16 @@ module Dor
         end
 
         # Initializes a new workspace
-        # @param source [String] the path to the object
+        # @param source [String] the path to the object (optional)
         # @raise [UnexpectedResponse] if the request is unsuccessful.
-        # @return nil
-        def create(source:)
+        # @return [String] the path to the directory created
+        def create(source: nil)
           resp = connection.post do |req|
             req.url workspace_path
-            req.params['source'] = source
+            req.params['source'] = source if source
           end
+          return resp.headers['Location'] if resp.success?
+
           raise_exception_based_on_response!(resp, object_identifier) unless resp.success?
         end
 

--- a/lib/dor/services/client/workspace.rb
+++ b/lib/dor/services/client/workspace.rb
@@ -20,7 +20,7 @@ module Dor
             req.url workspace_path
             req.params['source'] = source if source
           end
-          return resp.headers['Location'] if resp.success?
+          return JSON.parse(resp.body)['path'] if resp.success?
 
           raise_exception_based_on_response!(resp, object_identifier) unless resp.success?
         end

--- a/lib/dor/services/client/workspace.rb
+++ b/lib/dor/services/client/workspace.rb
@@ -13,12 +13,16 @@ module Dor
 
         # Initializes a new workspace
         # @param source [String] the path to the object (optional)
+        # @param content [Boolean] determines if the content directory should be created (defaults to false)
+        # @param metadata [Boolean] determines if the metadata directory should be created (defaults to false)
         # @raise [UnexpectedResponse] if the request is unsuccessful.
         # @return [String] the path to the directory created
-        def create(source: nil)
+        def create(source: nil, content: false, metadata: false)
           resp = connection.post do |req|
             req.url workspace_path
             req.params['source'] = source if source
+            req.params['content'] = content
+            req.params['metadata'] = metadata
           end
           return JSON.parse(resp.body)['path'] if resp.success?
 

--- a/spec/dor/services/client/workspace_spec.rb
+++ b/spec/dor/services/client/workspace_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Dor::Services::Client::Workspace do
       subject(:request) { client.create(source: source) }
 
       before do
-        stub_request(:post, "https://dor-services.example.com/v1/objects/druid:123/workspace?source=#{source}")
+        stub_request(:post, "https://dor-services.example.com/v1/objects/druid:123/workspace?source=#{source}&metadata=false&content=false")
           .to_return(status: 201, body: { path: path_to_workspace }.to_json)
       end
 
@@ -31,7 +31,46 @@ RSpec.describe Dor::Services::Client::Workspace do
       subject(:request) { client.create }
 
       before do
-        stub_request(:post, 'https://dor-services.example.com/v1/objects/druid:123/workspace')
+        stub_request(:post, 'https://dor-services.example.com/v1/objects/druid:123/workspace?metadata=false&content=false')
+          .to_return(status: 201, body: { path: path_to_workspace }.to_json)
+      end
+
+      it 'posts params and returns directory' do
+        expect(request).to eq path_to_workspace
+      end
+    end
+
+    context 'when API request succeeds without source param and with content param' do
+      subject(:request) { client.create(content: true) }
+
+      before do
+        stub_request(:post, 'https://dor-services.example.com/v1/objects/druid:123/workspace?metadata=false&content=true')
+          .to_return(status: 201, body: { path: path_to_workspace }.to_json)
+      end
+
+      it 'posts params and returns directory' do
+        expect(request).to eq path_to_workspace
+      end
+    end
+
+    context 'when API request succeeds without source param and with metadata param' do
+      subject(:request) { client.create(metadata: true) }
+
+      before do
+        stub_request(:post, 'https://dor-services.example.com/v1/objects/druid:123/workspace?metadata=true&content=false')
+          .to_return(status: 201, body: { path: path_to_workspace }.to_json)
+      end
+
+      it 'posts params and returns directory' do
+        expect(request).to eq path_to_workspace
+      end
+    end
+
+    context 'when API request succeeds without source param and with content and metadata params' do
+      subject(:request) { client.create(content: true, metadata: true) }
+
+      before do
+        stub_request(:post, 'https://dor-services.example.com/v1/objects/druid:123/workspace?metadata=true&content=true')
           .to_return(status: 201, body: { path: path_to_workspace }.to_json)
       end
 
@@ -44,7 +83,7 @@ RSpec.describe Dor::Services::Client::Workspace do
       subject(:request) { client.create(source: source) }
 
       before do
-        stub_request(:post, "https://dor-services.example.com/v1/objects/druid:123/workspace?source=#{source}")
+        stub_request(:post, "https://dor-services.example.com/v1/objects/druid:123/workspace?source=#{source}&metadata=false&content=false")
           .to_return(status: [500, 'something is amiss'])
       end
 

--- a/spec/dor/services/client/workspace_spec.rb
+++ b/spec/dor/services/client/workspace_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Dor::Services::Client::Workspace do
 
       before do
         stub_request(:post, "https://dor-services.example.com/v1/objects/druid:123/workspace?source=#{source}")
-          .to_return(status: 200, headers: { 'Location' => path_to_workspace })
+          .to_return(status: 201, body: { path: path_to_workspace }.to_json)
       end
 
       it 'posts params and returns directory' do
@@ -32,7 +32,7 @@ RSpec.describe Dor::Services::Client::Workspace do
 
       before do
         stub_request(:post, 'https://dor-services.example.com/v1/objects/druid:123/workspace')
-          .to_return(status: 200, headers: { 'Location' => path_to_workspace })
+          .to_return(status: 201, body: { path: path_to_workspace }.to_json)
       end
 
       it 'posts params and returns directory' do
@@ -67,7 +67,7 @@ RSpec.describe Dor::Services::Client::Workspace do
 
       before do
         stub_request(:delete, 'https://dor-services.example.com/v1/objects/druid:123/workspace?workflow=accessionWF&lane-id=low')
-          .to_return(status: 200, headers: { 'Location' => 'https://dor-services.example.com/v1/background_job_results/123' })
+          .to_return(status: 201, headers: { 'Location' => 'https://dor-services.example.com/v1/background_job_results/123' })
       end
 
       it 'returns a url' do
@@ -100,7 +100,7 @@ RSpec.describe Dor::Services::Client::Workspace do
 
       before do
         stub_request(:post, 'https://dor-services.example.com/v1/objects/druid:123/workspace/reset?workflow=accessionWF&lane-id=low')
-          .to_return(status: 200)
+          .to_return(status: 201)
       end
 
       it 'raises no errors' do

--- a/spec/dor/services/client/workspace_spec.rb
+++ b/spec/dor/services/client/workspace_spec.rb
@@ -11,22 +11,40 @@ RSpec.describe Dor::Services::Client::Workspace do
   let(:pid) { 'druid:123' }
 
   describe '#create' do
-    subject(:request) { client.create(source: 'abd/cwef/vwef/content') }
+    let(:path_to_workspace) { '/dor/workspace/123' }
+    let(:source) { 'abd/cwef/vwef/content' }
 
-    context 'when API request succeeds' do
+    context 'when API request succeeds with source param' do
+      subject(:request) { client.create(source: source) }
+
       before do
-        stub_request(:post, 'https://dor-services.example.com/v1/objects/druid:123/workspace?source=abd/cwef/vwef/content')
-          .to_return(status: 200)
+        stub_request(:post, "https://dor-services.example.com/v1/objects/druid:123/workspace?source=#{source}")
+          .to_return(status: 200, headers: { 'Location' => path_to_workspace })
       end
 
-      it 'posts params' do
-        expect(request).to be_nil
+      it 'posts params and returns directory' do
+        expect(request).to eq path_to_workspace
+      end
+    end
+
+    context 'when API request succeeds without source param' do
+      subject(:request) { client.create }
+
+      before do
+        stub_request(:post, 'https://dor-services.example.com/v1/objects/druid:123/workspace')
+          .to_return(status: 200, headers: { 'Location' => path_to_workspace })
+      end
+
+      it 'posts params and returns directory' do
+        expect(request).to eq path_to_workspace
       end
     end
 
     context 'when API request fails' do
+      subject(:request) { client.create(source: source) }
+
       before do
-        stub_request(:post, 'https://dor-services.example.com/v1/objects/druid:123/workspace?source=abd/cwef/vwef/content')
+        stub_request(:post, "https://dor-services.example.com/v1/objects/druid:123/workspace?source=#{source}")
           .to_return(status: [500, 'something is amiss'])
       end
 


### PR DESCRIPTION
## Why was this change made? 🤔

See https://github.com/sul-dlss/dor-services-app/pull/5042 

The returns the value of the directory created from the workspace create call.  Useful for ocrWF work.

HOLD for the PR above to be released

## How was this change tested? 🤨

Updated specs