### PR TITLE
[HOLD] indicate if object has active text extraction workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ object_client.notify_goobi
 object_client.version.inventory
 object_client.version.current
 # Returns a struct containing the status.
-# Status includes whether the object is open, assembling, accessioning, or closeable.
+# Status includes whether the object is open, assembling, text extracting, accessioning, or closeable.
 object_client.version.status
 object_client.version.openable?
 # see dor-services-app openapi.yml for optional params

--- a/lib/dor/services/client/object_version.rb
+++ b/lib/dor/services/client/object_version.rb
@@ -6,7 +6,7 @@ module Dor
       # API calls that are about versions
       class ObjectVersion < VersionedService
         Version = Struct.new(:versionId, :message, keyword_init: true)
-        VersionStatus = Struct.new(:versionId, :open, :openable, :assembling, :accessioning, :closeable, keyword_init: true) do
+        VersionStatus = Struct.new(:versionId, :open, :openable, :assembling, :text_extracting, :accessioning, :closeable, keyword_init: true) do
           alias_method :version, :versionId
 
           def open?
@@ -19,6 +19,10 @@ module Dor
 
           def assembling?
             assembling
+          end
+
+          def text_extracting?
+            text_extracting
           end
 
           def accessioning?

--- a/spec/dor/services/client/object_version_spec.rb
+++ b/spec/dor/services/client/object_version_spec.rb
@@ -332,16 +332,18 @@ RSpec.describe Dor::Services::Client::ObjectVersion do
 
       let(:body) do
         <<~JSON
-          {"versionId":1,"open":true,"openable":false,"assembling":true,"accessioning":false,"closeable":true}
+          {"versionId":1,"open":true,"openable":false,"assembling":true,"text_extracting":false,"accessioning":false,"closeable":true}
         JSON
       end
 
       it 'returns the list of versions' do
-        expect(request).to eq described_class::VersionStatus.new(versionId: 1, open: true, openable: false, assembling: true, accessioning: false, closeable: true)
+        expect(request).to eq described_class::VersionStatus.new(versionId: 1, open: true, openable: false, assembling: true, text_extracting: false,
+                                                                 accessioning: false, closeable: true)
         expect(request.version).to eq 1
         expect(request).to be_open
         expect(request).not_to be_openable
         expect(request).to be_assembling
+        expect(request).not_to be_text_extracting
         expect(request).not_to be_accessioning
         expect(request).not_to be_closed
         expect(request).to be_closeable


### PR DESCRIPTION
## Why was this change made? 🤔

Part of https://github.com/sul-dlss/argo/issues/4470

We need the ability to know if an object is in the middle of a text extraction WF (e.g. ocrWF) so we can disable various things (like editing or starting a new ocrWF in Argo).

HOLD for https://github.com/sul-dlss/dor-services-app/pull/5080 for the DSA related change

## How was this change tested? 🤨

Updated tests