### PR TITLE
Adds user version solr endpoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ object_client.version.close
 # Manage user versions
 object_client.user_version.inventory
 object_client.user_version.find(2)
+object_client.user_version.solr(2)
 object_client.user_version.create(object_version: 3)
 object_client.user_version.update(user_version: Dor::Services::Client::UserVersion::Version.new(version: 3, userVersion: 3, withdrawn: true))
 

--- a/lib/dor/services/client/user_version.rb
+++ b/lib/dor/services/client/user_version.rb
@@ -35,6 +35,17 @@ module Dor
           build_cocina_from_response(resp, validate: false)
         end
 
+        # @return [Hash] the solr document for the user version
+        # @raise [UnexpectedResponse] on an unsuccessful response from the server
+        def solr(version)
+          resp = connection.get do |req|
+            req.url "#{base_path}/#{version}/solr"
+          end
+          raise_exception_based_on_response!(resp) unless resp.success?
+
+          JSON.parse(resp.body)
+        end
+
         # Create a user version for an object
         #
         # @param [String] object_version the version of the object to create a user version for

--- a/spec/dor/services/client/user_version_spec.rb
+++ b/spec/dor/services/client/user_version_spec.rb
@@ -98,6 +98,34 @@ RSpec.describe Dor::Services::Client::UserVersion do
     end
   end
 
+  describe '#solr' do
+    subject(:solr) { client.solr(2) }
+
+    let(:expected_solr) do
+      {
+        'id' => druid,
+        'current_version_isi' => 1,
+        'obj_label_tesim' => 'Test DRO',
+        'modified_latest_dttsi' => '2024-07-03T12:32:16Z',
+        'created_at_dttsi' => '2024-07-03T12:32:16Z',
+        'is_governed_by_ssim' => 'info:fedora/druid:hy787xj5878',
+        'objectType_ssim' => ['item']
+      }
+    end
+
+    before do
+      stub_request(:get, 'https://dor-services.example.com/v1/objects/druid:bc123df4567/user_versions/2/solr')
+        .to_return(status: 200,
+                   body: expected_solr.to_json)
+    end
+
+    context 'when API request succeeds' do
+      it 'returns the solr document' do
+        expect(solr).to eq expected_solr
+      end
+    end
+  end
+
   describe '#create' do
     subject(:request) { client.create(object_version: '3') }
 


### PR DESCRIPTION
refs https://github.com/sul-dlss/argo/issues/4515

## Why was this change made? 🤔
So that Argo could render user versions based on solr document.


## How was this change tested? 🤨
Unit


⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



