### PR TITLE
remove cleanup call; reset calls does everything now

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,9 +164,8 @@ object_client.release_tags.list(public: true) # only public release tags (i.e. l
 object_client.events.create(type: type, data: data)
 object_client.events.list
 
-# Create, remove, and reset workspaces
+# Create and reset workspaces
 object_client.workspace.create(source: object_path_string)
-object_client.workspace.cleanup
 object_client.workspace.reset
 
 # Reindex

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ object_client.events.list
 
 # Create and reset workspaces
 object_client.workspace.create(source: object_path_string)
-object_client.workspace.reset
+object_client.workspace.cleanup
 
 # Reindex
 object_client.reindex

--- a/lib/dor/services/client/workspace.rb
+++ b/lib/dor/services/client/workspace.rb
@@ -31,32 +31,21 @@ module Dor
         end
         # rubocop:enable Metrics/AbcSize
 
-        # Cleans up a workspace
+        # Cleans up and resets the workspace
+        # After an object has been copied to preservation the workspace can be
+        # reset. This is called by the reset-workspace step of the accessionWF
         # @raise [NotFoundResponse] when the response is a 404 (object not found)
         # @raise [UnexpectedResponse] when the response is not successful.
         # @param [String] workflow (nil) which workflow to callback to.
         # @param [String] lane_id for prioritization (default or low)
         # @return [String] the URL of the background job on dor-service-app
-        def cleanup(workflow: nil, lane_id: nil)
+        def reset(workflow: nil, lane_id: nil)
           resp = connection.delete do |req|
             req.url with_query_params(workspace_path, workflow, lane_id)
           end
           return resp.headers['Location'] if resp.success?
 
           raise_exception_based_on_response!(resp, object_identifier)
-        end
-
-        # After an object has been copied to preservation the workspace can be
-        # reset. This is called by the reset-workspace step of the accessionWF
-        # @param [String] workflow (nil) which workflow to callback to.
-        # @param [String] lane_id for prioritization (default or low)
-        # @raise [UnexpectedResponse] if the request is unsuccessful.
-        # @return nil
-        def reset(workflow: nil, lane_id: nil)
-          resp = connection.post do |req|
-            req.url with_query_params("#{workspace_path}/reset", workflow, lane_id)
-          end
-          raise_exception_based_on_response!(resp, object_identifier) unless resp.success?
         end
 
         private

--- a/lib/dor/services/client/workspace.rb
+++ b/lib/dor/services/client/workspace.rb
@@ -39,7 +39,7 @@ module Dor
         # @param [String] workflow (nil) which workflow to callback to.
         # @param [String] lane_id for prioritization (default or low)
         # @return [String] the URL of the background job on dor-service-app
-        def reset(workflow: nil, lane_id: nil)
+        def cleanup(workflow: nil, lane_id: nil)
           resp = connection.delete do |req|
             req.url with_query_params(workspace_path, workflow, lane_id)
           end

--- a/spec/dor/services/client/workspace_spec.rb
+++ b/spec/dor/services/client/workspace_spec.rb
@@ -94,39 +94,6 @@ RSpec.describe Dor::Services::Client::Workspace do
     end
   end
 
-  describe '#cleanup' do
-    subject(:request) { client.cleanup(workflow: workflow, lane_id: lane_id) }
-
-    let(:workflow) { nil }
-    let(:lane_id) { nil }
-
-    context 'when API request succeeds' do
-      let(:workflow) { 'accessionWF' }
-      let(:lane_id) { 'low' }
-
-      before do
-        stub_request(:delete, 'https://dor-services.example.com/v1/objects/druid:123/workspace?workflow=accessionWF&lane-id=low')
-          .to_return(status: 201, headers: { 'Location' => 'https://dor-services.example.com/v1/background_job_results/123' })
-      end
-
-      it 'returns a url' do
-        expect(request).to eq 'https://dor-services.example.com/v1/background_job_results/123'
-      end
-    end
-
-    context 'when API request fails' do
-      before do
-        stub_request(:delete, 'https://dor-services.example.com/v1/objects/druid:123/workspace')
-          .to_return(status: [500, 'something is amiss'])
-      end
-
-      it 'raises an error' do
-        expect { request }.to raise_error(Dor::Services::Client::UnexpectedResponse,
-                                          "something is amiss: 500 (#{Dor::Services::Client::ResponseErrorFormatter::DEFAULT_BODY}) for druid:123")
-      end
-    end
-  end
-
   describe '#reset' do
     subject(:request) { client.reset(workflow: workflow, lane_id: lane_id) }
 
@@ -138,7 +105,7 @@ RSpec.describe Dor::Services::Client::Workspace do
       let(:lane_id) { 'low' }
 
       before do
-        stub_request(:post, 'https://dor-services.example.com/v1/objects/druid:123/workspace/reset?workflow=accessionWF&lane-id=low')
+        stub_request(:delete, 'https://dor-services.example.com/v1/objects/druid:123/workspace?workflow=accessionWF&lane-id=low')
           .to_return(status: 201)
       end
 
@@ -149,7 +116,7 @@ RSpec.describe Dor::Services::Client::Workspace do
 
     context 'when API request fails' do
       before do
-        stub_request(:post, 'https://dor-services.example.com/v1/objects/druid:123/workspace/reset')
+        stub_request(:delete, 'https://dor-services.example.com/v1/objects/druid:123/workspace')
           .to_return(status: [500, 'something is amiss'])
       end
 

--- a/spec/dor/services/client/workspace_spec.rb
+++ b/spec/dor/services/client/workspace_spec.rb
@@ -94,8 +94,8 @@ RSpec.describe Dor::Services::Client::Workspace do
     end
   end
 
-  describe '#reset' do
-    subject(:request) { client.reset(workflow: workflow, lane_id: lane_id) }
+  describe '#cleanup' do
+    subject(:request) { client.cleanup(workflow: workflow, lane_id: lane_id) }
 
     let(:workflow) { nil }
     let(:lane_id) { nil }


### PR DESCRIPTION
## Why was this change made? 🤔

Part of https://github.com/sul-dlss/dor-services-app/issues/5110

Fixes #473

Combining reset and cleanup into one API call, so it can made from a single job in DSA (and called from just the accessionWF:reset-workspace robot)

We need to coordinate changes in [DSA](https://github.com/sul-dlss/dor-services-app/pull/5183) and [common-accessioning](https://github.com/sul-dlss/common-accessioning/pull/1380)

## How was this change tested? 🤨

Specs
Integration tests