### PR TITLE
remove workflow param from cleanup

### DIFF
--- a/spec/dor/services/client/workspace_spec.rb
+++ b/spec/dor/services/client/workspace_spec.rb
@@ -95,17 +95,15 @@ RSpec.describe Dor::Services::Client::Workspace do
   end
 
   describe '#cleanup' do
-    subject(:request) { client.cleanup(workflow: workflow, lane_id: lane_id) }
+    subject(:request) { client.cleanup(lane_id: lane_id) }
 
-    let(:workflow) { nil }
     let(:lane_id) { nil }
 
     context 'when API request succeeds' do
-      let(:workflow) { 'accessionWF' }
       let(:lane_id) { 'low' }
 
       before do
-        stub_request(:delete, 'https://dor-services.example.com/v1/objects/druid:123/workspace?workflow=accessionWF&lane-id=low')
+        stub_request(:delete, 'https://dor-services.example.com/v1/objects/druid:123/workspace?lane-id=low')
           .to_return(status: 201)
       end
 


### PR DESCRIPTION
## Why was this change made? 🤔

Part of https://github.com/sul-dlss/common-accessioning/issues/1387

DisseminationWF is gone (see https://github.com/sul-dlss/dor-services-app/pull/1385), so remove it's reference. We also don't need to bother even asking for the workflow anymore for this endpoint since it's always going to be accessionWF.

This changes needs to be coordinated with https://github.com/sul-dlss/common-accessioning/pull/1386 and https://github.com/sul-dlss/dor-services-app/pull/5186

HOLD for #1385

Process:
1. Merge https://github.com/sul-dlss/dor-services-client/pull/475 and then cut a new release
2. Update https://github.com/sul-dlss/common-accessioning/pull/1386 to use new dor-services-client release, merge it
3. Merge https://github.com/sul-dlss/dor-services-app/pull/5186
4. Deploy all


## How was this change tested? 🤨

Spec



