### PR TITLE
Remove workflow param from object publish.

### DIFF
--- a/lib/dor/services/client/transfer.rb
+++ b/lib/dor/services/client/transfer.rb
@@ -14,12 +14,10 @@ module Dor
         # Publish an object (send to PURL)
         # @raise [NotFoundResponse] when the response is a 404 (object not found)
         # @raise [UnexpectedResponse] when the response is not successful.
-        # @param [String] workflow (nil) which workflow to callback to.
         # @param [String] lane_id for prioritization (default or low)
         # @return [String] the URL of the background job on dor-service-app
-        def publish(workflow: nil, lane_id: nil)
+        def publish(lane_id: nil)
           query_params = [].tap do |params|
-            params << "workflow=#{workflow}" if workflow
             params << "lane-id=#{lane_id}" if lane_id
           end
           query_string = query_params.any? ? "?#{query_params.join('&')}" : ''

--- a/spec/dor/services/client/object_spec.rb
+++ b/spec/dor/services/client/object_spec.rb
@@ -384,12 +384,12 @@ RSpec.describe Dor::Services::Client::Object do
   end
 
   describe '#publish' do
-    subject(:request) { client.publish(workflow: 'accessionWF', lane_id: 'low') }
+    subject(:request) { client.publish(lane_id: 'low') }
 
     subject(:no_wf_request) { client.publish }
 
     before do
-      stub_request(:post, 'https://dor-services.example.com/v1/objects/druid:bc123df4567/publish?workflow=accessionWF&lane-id=low')
+      stub_request(:post, 'https://dor-services.example.com/v1/objects/druid:bc123df4567/publish?lane-id=low')
         .to_return(status: status, headers: { 'Location' => 'https://dor-services.example.com/v1/background_job_results/123' })
       stub_request(:post, 'https://dor-services.example.com/v1/objects/druid:bc123df4567/publish')
         .to_return(status: status, headers: { 'Location' => 'https://dor-services.example.com/v1/background_job_results/123' })


### PR DESCRIPTION
## Why was this change made? 🤔
Param is deprecated.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



