### PR TITLE
Adds support for getting version status in batch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ object_client.version.current
 # Returns a struct containing the status.
 # Status includes whether the object is open, assembling, accessioning, or closeable.
 object_client.version.status
+# Get status for a batch of objects
+objects_client.statuses(object_ids: ['druid:bc123df4567', 'druid:bc987gh6543'])
 # see dor-services-app openapi.yml for optional params
 object_client.version.open(description: 'Changed title')
 # see dor-services-app openapi.yml for optional params

--- a/lib/dor/services/client/objects.rb
+++ b/lib/dor/services/client/objects.rb
@@ -41,6 +41,22 @@ module Dor
           build_cocina_from_response(resp, validate: validate)
         end
 
+        # Retrieves the version statuses for a batch of objects
+        # @param [Array<String>] object_ids the druids to get statuses for
+        # @return [Hash<String,VersionStatus>] Map of druids to statuses
+        # @raise [UnexpectedResponse] on an unsuccessful response from the server
+        def statuses(object_ids:)
+          resp = connection.post do |req|
+            req.url "#{objects_path}/versions/status"
+            req.headers['Content-Type'] = 'application/json'
+            req.body = { externalIdentifiers: object_ids }.to_json
+          end
+
+          raise_exception_based_on_response!(resp) unless resp.success?
+
+          JSON.parse(resp.body).transform_values { |status| ObjectVersion::VersionStatus.new(status.symbolize_keys!) }
+        end
+
         private
 
         def objects_path


### PR DESCRIPTION
refs https://github.com/sul-dlss/dor-services-app/issues/5243

## Why was this change made? 🤔
To make rendering the H3 dashboard more efficient.


## How was this change tested? 🤨
Unit, stage

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



