### PR TITLE
Adds version description to version status.

### DIFF
--- a/lib/dor/services/client/object_version.rb
+++ b/lib/dor/services/client/object_version.rb
@@ -13,8 +13,10 @@ module Dor
           end
         end
 
-        VersionStatus = Struct.new(:versionId, :open, :openable, :assembling, :accessioning, :closeable, :discardable, keyword_init: true) do
+        VersionStatus = Struct.new(:versionId, :open, :openable, :assembling, :accessioning, :closeable, :discardable,
+                                   :versionDescription, keyword_init: true) do
           alias_method :version, :versionId
+          alias_method :version_description, :versionDescription
 
           def open?
             open

--- a/spec/dor/services/client/object_version_spec.rb
+++ b/spec/dor/services/client/object_version_spec.rb
@@ -362,14 +362,14 @@ RSpec.describe Dor::Services::Client::ObjectVersion do
 
       let(:body) do
         <<~JSON
-          {"versionId":1,"open":true,"openable":false,"assembling":true,"accessioning":false,"closeable":true,"discardable":false}
+          {"versionId":1,"open":true,"openable":false,"assembling":true,"accessioning":false,"closeable":true,"discardable":false,"versionDescription":"Initial version"}
         JSON
       end
 
       it 'returns the list of versions' do
         expect(request).to eq described_class::VersionStatus.new(versionId: 1, open: true, openable: false,
                                                                  assembling: true, accessioning: false, closeable: true,
-                                                                 discardable: false)
+                                                                 discardable: false, versionDescription: 'Initial version')
         expect(request.version).to eq 1
         expect(request).to be_open
         expect(request).not_to be_openable
@@ -378,6 +378,7 @@ RSpec.describe Dor::Services::Client::ObjectVersion do
         expect(request).not_to be_closed
         expect(request).to be_closeable
         expect(request).not_to be_discardable
+        expect(request.version_description).to eq 'Initial version'
       end
     end
 


### PR DESCRIPTION
refs https://github.com/sul-dlss/hungry-hungry-hippo/issues/704

## Why was this change made? 🤔
To expose the version description for H3.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



