### PR TITLE
allow update client calls to pass in event data for the DSA event service

### DIFF
--- a/lib/dor/services/client/mutate.rb
+++ b/lib/dor/services/client/mutate.rb
@@ -43,7 +43,8 @@ module Dor
           raise ArgumentError, 'ETag not provided.' unless skip_lock || params.respond_to?(:lock)
 
           resp = connection.patch do |req|
-            req.url "#{object_path}?event_data=#{event_data.to_json}"
+            req.url object_path
+            req.params = { event_data: event_data.to_json }
             req.headers['Content-Type'] = 'application/json'
             # asking the service to return JSON (else it'll be plain text)
             req.headers['Accept'] = 'application/json'

--- a/lib/dor/services/client/mutate.rb
+++ b/lib/dor/services/client/mutate.rb
@@ -29,20 +29,21 @@ module Dor
         # @param [Cocina::Models::DROWithMetadata|CollectionWithMetadata|AdminPolicyWithMetadata|DRO|Collection|AdminPolicy] params model object
         # @param [boolean] skip_lock do not provide ETag
         # @param [boolean] validate validate the response object
+        # @param [Hash] event_data additional event data to be added to the update object event
         # @raise [NotFoundResponse] when the response is a 404 (object not found)
         # @raise [UnexpectedResponse] when the response is not successful.
         # @raise [BadRequestError] when ETag not provided.
         # @return [Cocina::Models::DROWithMetadata,Cocina::Models::CollectionWithMetadata,Cocina::Models::AdminPolicyWithMetadata] the returned model
         # rubocop:disable Metrics/AbcSize
         # rubocop:disable Metrics/MethodLength
-        def update(params:, skip_lock: false, validate: false)
+        def update(params:, skip_lock: false, validate: false, event_data: {})
           raise ArgumentError, 'Cocina object not provided.' unless params.respond_to?(:externalIdentifier)
 
           # Raised if Cocina::Models::*WithMetadata not provided.
           raise ArgumentError, 'ETag not provided.' unless skip_lock || params.respond_to?(:lock)
 
           resp = connection.patch do |req|
-            req.url object_path
+            req.url "#{object_path}?event_data=#{event_data.to_json}"
             req.headers['Content-Type'] = 'application/json'
             # asking the service to return JSON (else it'll be plain text)
             req.headers['Accept'] = 'application/json'

--- a/lib/dor/services/client/objects.rb
+++ b/lib/dor/services/client/objects.rb
@@ -5,7 +5,7 @@ require 'deprecation'
 module Dor
   module Services
     class Client
-      # API calls that are about a repository objects
+      # API calls that are about repository objects
       class Objects < VersionedService
         # Creates a new object in DOR
         # @param params [Cocina::Models::RequestDRO,Cocina::Models::RequestCollection,Cocina::Models::RequestAdminPolicy]


### PR DESCRIPTION
## Why was this change made? 🤔

Part of https://github.com/sul-dlss/hungry-hungry-hippo/issues/1371

We want to have object update events pass on extra metadata that a client provides to the event.  This change to the dsa-client will then pass along the metadata to DSA for processing into the event.

Depends on https://github.com/sul-dlss/dor-services-app/pull/5364 first

## How was this change tested? 🤨

Specs


