### PR TITLE
use who/description instead of general hash

### DIFF
--- a/lib/dor/services/client/accession.rb
+++ b/lib/dor/services/client/accession.rb
@@ -25,7 +25,8 @@ module Dor
         def start(params = {})
           body = params[:context] ? { 'context' => params[:context] }.to_json : ''
           resp = connection.post do |req|
-            req.url with_querystring(url: path, params: params.except(:context))
+            req.url path
+            req.params = params.except(:context)
             req.headers['Content-Type'] = 'application/json'
             req.body = body
           end

--- a/lib/dor/services/client/mutate.rb
+++ b/lib/dor/services/client/mutate.rb
@@ -45,7 +45,7 @@ module Dor
 
           resp = connection.patch do |req|
             req.url object_path
-            req.params = { description: description, who: who }.compact
+            req.params = { event_description: description, event_who: who }.compact
             req.headers['Content-Type'] = 'application/json'
             # asking the service to return JSON (else it'll be plain text)
             req.headers['Accept'] = 'application/json'

--- a/lib/dor/services/client/mutate.rb
+++ b/lib/dor/services/client/mutate.rb
@@ -29,14 +29,15 @@ module Dor
         # @param [Cocina::Models::DROWithMetadata|CollectionWithMetadata|AdminPolicyWithMetadata|DRO|Collection|AdminPolicy] params model object
         # @param [boolean] skip_lock do not provide ETag
         # @param [boolean] validate validate the response object
-        # @param [Hash] event_data additional event data to be added to the update object event
+        # @param [string] who the sunetid of the user performing the update
+        # @param [string] description a description of the update
         # @raise [NotFoundResponse] when the response is a 404 (object not found)
         # @raise [UnexpectedResponse] when the response is not successful.
         # @raise [BadRequestError] when ETag not provided.
         # @return [Cocina::Models::DROWithMetadata,Cocina::Models::CollectionWithMetadata,Cocina::Models::AdminPolicyWithMetadata] the returned model
         # rubocop:disable Metrics/AbcSize
         # rubocop:disable Metrics/MethodLength
-        def update(params:, skip_lock: false, validate: false, event_data: {})
+        def update(params:, skip_lock: false, validate: false, who: nil, description: nil)
           raise ArgumentError, 'Cocina object not provided.' unless params.respond_to?(:externalIdentifier)
 
           # Raised if Cocina::Models::*WithMetadata not provided.
@@ -44,7 +45,7 @@ module Dor
 
           resp = connection.patch do |req|
             req.url object_path
-            req.params = { event_data: event_data.to_json }
+            req.params = { description: description, who: who }
             req.headers['Content-Type'] = 'application/json'
             # asking the service to return JSON (else it'll be plain text)
             req.headers['Accept'] = 'application/json'

--- a/lib/dor/services/client/mutate.rb
+++ b/lib/dor/services/client/mutate.rb
@@ -45,7 +45,7 @@ module Dor
 
           resp = connection.patch do |req|
             req.url object_path
-            req.params = { description: description, who: who }
+            req.params = { description: description, who: who }.compact
             req.headers['Content-Type'] = 'application/json'
             # asking the service to return JSON (else it'll be plain text)
             req.headers['Accept'] = 'application/json'

--- a/lib/dor/services/client/object_version.rb
+++ b/lib/dor/services/client/object_version.rb
@@ -86,7 +86,8 @@ module Dor
         # @return [Cocina::Models::DROWithMetadata|CollectionWithMetadata|AdminPolicyWithMetadata] cocina model with updated version
         def open(**params)
           resp = connection.post do |req|
-            req.url with_querystring(url: open_new_version_path, params: params)
+            req.url open_new_version_path
+            req.params = params
             req.headers['Content-Type'] = 'application/json'
           end
 
@@ -105,7 +106,8 @@ module Dor
         # @return [String] a message confirming successful closing
         def close(**params)
           resp = connection.post do |req|
-            req.url with_querystring(url: close_version_path, params: params)
+            req.url close_version_path
+            req.params = params
             req.headers['Content-Type'] = 'application/json'
           end
           return resp.body if resp.success?

--- a/lib/dor/services/client/objects.rb
+++ b/lib/dor/services/client/objects.rb
@@ -16,7 +16,7 @@ module Dor
         def register(params:, assign_doi: false, validate: false, who: nil)
           resp = connection.post do |req|
             req.url objects_path
-            req.params = { assign_doi: assign_doi, who: who }.compact
+            req.params = { assign_doi: assign_doi, event_who: who }.compact
             req.headers['Content-Type'] = 'application/json'
             # asking the service to return JSON (else it'll be plain text)
             req.headers['Accept'] = 'application/json'

--- a/lib/dor/services/client/objects.rb
+++ b/lib/dor/services/client/objects.rb
@@ -9,12 +9,14 @@ module Dor
       class Objects < VersionedService
         # Creates a new object in DOR
         # @param params [Cocina::Models::RequestDRO,Cocina::Models::RequestCollection,Cocina::Models::RequestAdminPolicy]
-        # @param assign_doi [Boolean]
+        # @param [boolean] assign a doi to the object
+        # @param [string] who the sunetid of the user registering the object
         # @param [boolean] validate validate the response object
         # @return [Cocina::Models::DROWithMetadata,Cocina::Models::CollectionWithMetadata,Cocina::Models::AdminPolicyWithMetadata] the returned model
-        def register(params:, assign_doi: false, validate: false)
+        def register(params:, assign_doi: false, validate: false, who: nil)
           resp = connection.post do |req|
-            req.url with_querystring(url: objects_path, params: { assign_doi: assign_doi })
+            req.url objects_path
+            req.params = { assign_doi: assign_doi, who: who }.compact
             req.headers['Content-Type'] = 'application/json'
             # asking the service to return JSON (else it'll be plain text)
             req.headers['Accept'] = 'application/json'

--- a/lib/dor/services/client/versioned_service.rb
+++ b/lib/dor/services/client/versioned_service.rb
@@ -25,12 +25,6 @@ module Dor
           AsyncResult.new(url: url)
         end
 
-        def with_querystring(url:, params:)
-          return url if params.blank?
-
-          "#{url}?#{params.to_query}"
-        end
-
         private
 
         attr_reader :connection, :api_version

--- a/spec/dor/services/client/object_spec.rb
+++ b/spec/dor/services/client/object_spec.rb
@@ -320,7 +320,7 @@ RSpec.describe Dor::Services::Client::Object do
       let(:description) { '' }
 
       before do
-        stub_request(:patch, 'https://dor-services.example.com/v1/objects/druid:bc123df4567?who&description')
+        stub_request(:patch, 'https://dor-services.example.com/v1/objects/druid:bc123df4567')
           .with(
             body: json,
             headers: {
@@ -397,7 +397,7 @@ RSpec.describe Dor::Services::Client::Object do
       let(:event_data) { {} }
 
       before do
-        stub_request(:patch, 'https://dor-services.example.com/v1/objects/druid:bc123df4567?who&description')
+        stub_request(:patch, 'https://dor-services.example.com/v1/objects/druid:bc123df4567')
           .with(
             body: json,
             headers: {

--- a/spec/dor/services/client/object_spec.rb
+++ b/spec/dor/services/client/object_spec.rb
@@ -316,10 +316,11 @@ RSpec.describe Dor::Services::Client::Object do
     context 'when API request succeeds with DRO' do
       subject(:model) { client.update(params: dro_with_metadata) }
 
-      let(:event_data) { {} }
+      let(:who) { '' }
+      let(:description) { '' }
 
       before do
-        stub_request(:patch, "https://dor-services.example.com/v1/objects/druid:bc123df4567?event_data=#{event_data.to_json}")
+        stub_request(:patch, 'https://dor-services.example.com/v1/objects/druid:bc123df4567?who&description')
           .with(
             body: json,
             headers: {
@@ -345,12 +346,13 @@ RSpec.describe Dor::Services::Client::Object do
     end
 
     context 'when some event data is provided' do
-      subject(:model) { client.update(params: dro_with_metadata, event_data: event_data) }
+      subject(:model) { client.update(params: dro_with_metadata, who: who, description: description) }
 
-      let(:event_data) { { who: 'test_user', description: 'update stuff' } }
+      let(:who) { 'test_user' }
+      let(:description) { 'update stuff' }
 
       before do
-        stub_request(:patch, "https://dor-services.example.com/v1/objects/druid:bc123df4567?event_data=#{event_data.to_json}")
+        stub_request(:patch, "https://dor-services.example.com/v1/objects/druid:bc123df4567?description=#{description}&who=#{who}")
           .with(
             body: json,
             headers: {
@@ -372,7 +374,7 @@ RSpec.describe Dor::Services::Client::Object do
       it 'sends the event data in the patch request in the querystring' do
         expect(model.externalIdentifier).to eq 'druid:bc123df4567'
         expect(model.lock).to eq('W/"e541d8cd98f00b204e9800998ecf8427f"')
-        expect(WebMock).to have_requested(:patch, "https://dor-services.example.com/v1/objects/druid:bc123df4567?event_data=#{event_data.to_json}")
+        expect(WebMock).to have_requested(:patch, "https://dor-services.example.com/v1/objects/druid:bc123df4567?description=#{description}&who=#{who}")
           .with(body: json, headers: { 'If-Match' => lock, 'Content-Type' => 'application/json', 'Accept' => 'application/json' })
       end
     end
@@ -395,7 +397,7 @@ RSpec.describe Dor::Services::Client::Object do
       let(:event_data) { {} }
 
       before do
-        stub_request(:patch, "https://dor-services.example.com/v1/objects/druid:bc123df4567?event_data=#{event_data.to_json}")
+        stub_request(:patch, 'https://dor-services.example.com/v1/objects/druid:bc123df4567?who&description')
           .with(
             body: json,
             headers: {

--- a/spec/dor/services/client/object_spec.rb
+++ b/spec/dor/services/client/object_spec.rb
@@ -352,7 +352,7 @@ RSpec.describe Dor::Services::Client::Object do
       let(:description) { 'update stuff' }
 
       before do
-        stub_request(:patch, "https://dor-services.example.com/v1/objects/druid:bc123df4567?description=#{description}&who=#{who}")
+        stub_request(:patch, "https://dor-services.example.com/v1/objects/druid:bc123df4567?event_description=#{description}&event_who=#{who}")
           .with(
             body: json,
             headers: {
@@ -374,7 +374,7 @@ RSpec.describe Dor::Services::Client::Object do
       it 'sends the event data in the patch request in the querystring' do
         expect(model.externalIdentifier).to eq 'druid:bc123df4567'
         expect(model.lock).to eq('W/"e541d8cd98f00b204e9800998ecf8427f"')
-        expect(WebMock).to have_requested(:patch, "https://dor-services.example.com/v1/objects/druid:bc123df4567?description=#{description}&who=#{who}")
+        expect(WebMock).to have_requested(:patch, "https://dor-services.example.com/v1/objects/druid:bc123df4567?event_description=#{description}&event_who=#{who}")
           .with(body: json, headers: { 'If-Match' => lock, 'Content-Type' => 'application/json', 'Accept' => 'application/json' })
       end
     end

--- a/spec/dor/services/client/objects_spec.rb
+++ b/spec/dor/services/client/objects_spec.rb
@@ -66,6 +66,15 @@ RSpec.describe Dor::Services::Client::Objects do
       end
     end
 
+    context 'when passing in the person who registered the object' do
+      let(:url) { "https://dor-services.example.com/v1/objects?assign_doi=false&who=#{who}" }
+      let(:who) { 'test_user' }
+
+      it 'posts with who param' do
+        expect { client.register(params: request_dro, assign_doi: false, who: who) }.not_to raise_error
+      end
+    end
+
     context 'when API request fails' do
       context 'when Conflict (409) response' do
         let(:status) { [409, 'object already exists'] }

--- a/spec/dor/services/client/objects_spec.rb
+++ b/spec/dor/services/client/objects_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Dor::Services::Client::Objects do
     end
 
     context 'when passing in the person who registered the object' do
-      let(:url) { "https://dor-services.example.com/v1/objects?assign_doi=false&who=#{who}" }
+      let(:url) { "https://dor-services.example.com/v1/objects?assign_doi=false&event_who=#{who}" }
       let(:who) { 'test_user' }
 
       it 'posts with who param' do


### PR DESCRIPTION
## Why was this change made? 🤔

Ref https://github.com/sul-dlss/hungry-hungry-hippo/issues/1411 and https://github.com/sul-dlss/hungry-hungry-hippo/issues/1371

1 .Getting away from using general event hash and instead using specific params for who and description.  
2. Add who param to the registration event.
3. Refactoring to make adding params to the calls more idiomatic and consistent.
4. Namespace these params when passing to DSA so we don't confused "description" with cocina description (also in the params)

Requires https://github.com/sul-dlss/dor-services-app/pull/5366

## How was this change tested? 🤨

Spec