### PR TITLE
we use user_name in other spots, do it here too

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ objects_client = Dor::Services::Client.objects
 
 # Register a non-existent object
 objects_client.register(params: {})
-objects_client.register(params: {}, assign_doi: true)
+objects_client.register(params: {}, assign_doi: true, user_name: 'dude')
 
 # Find object by source ID
 objects_client.find(source_id: 'sul:abc123')
@@ -84,7 +84,7 @@ background_jobs_client.show(job_id: 123)
 object_client = Dor::Services::Client.object(object_identifier)
 
 # Update an object
-object_client.update(params: dro)
+object_client.update(params: dro, user_name: 'dude', description: 'things change sometimes')
 
 # Publish an object (push to PURL)
 object_client.publish(workflow: 'releaseWF', lane_id: 'low')

--- a/lib/dor/services/client/mutate.rb
+++ b/lib/dor/services/client/mutate.rb
@@ -29,7 +29,7 @@ module Dor
         # @param [Cocina::Models::DROWithMetadata|CollectionWithMetadata|AdminPolicyWithMetadata|DRO|Collection|AdminPolicy] params model object
         # @param [boolean] skip_lock do not provide ETag
         # @param [boolean] validate validate the response object
-        # @param [string] who the sunetid of the user performing the update
+        # @param [string] user_name the sunetid of the user performing the update
         # @param [string] description a description of the update
         # @raise [NotFoundResponse] when the response is a 404 (object not found)
         # @raise [UnexpectedResponse] when the response is not successful.
@@ -37,7 +37,7 @@ module Dor
         # @return [Cocina::Models::DROWithMetadata,Cocina::Models::CollectionWithMetadata,Cocina::Models::AdminPolicyWithMetadata] the returned model
         # rubocop:disable Metrics/AbcSize
         # rubocop:disable Metrics/MethodLength
-        def update(params:, skip_lock: false, validate: false, who: nil, description: nil)
+        def update(params:, skip_lock: false, validate: false, user_name: nil, description: nil)
           raise ArgumentError, 'Cocina object not provided.' unless params.respond_to?(:externalIdentifier)
 
           # Raised if Cocina::Models::*WithMetadata not provided.
@@ -45,7 +45,7 @@ module Dor
 
           resp = connection.patch do |req|
             req.url object_path
-            req.params = { event_description: description, event_who: who }.compact
+            req.params = { event_description: description, user_name: user_name }.compact
             req.headers['Content-Type'] = 'application/json'
             # asking the service to return JSON (else it'll be plain text)
             req.headers['Accept'] = 'application/json'
@@ -80,10 +80,9 @@ module Dor
         # @raise [NotFoundResponse] when the response is a 404 (object not found)
         # @raise [UnexpectedResponse] if the request is unsuccessful.
         def destroy(user_name: nil)
-          path = object_path
-          path += "?user_name=#{user_name}" if user_name
           resp = connection.delete do |req|
-            req.url path
+            req.url object_path
+            req.params = { user_name: user_name }.compact
           end
           raise_exception_based_on_response!(resp, object_identifier) unless resp.success?
 

--- a/lib/dor/services/client/objects.rb
+++ b/lib/dor/services/client/objects.rb
@@ -10,13 +10,13 @@ module Dor
         # Creates a new object in DOR
         # @param params [Cocina::Models::RequestDRO,Cocina::Models::RequestCollection,Cocina::Models::RequestAdminPolicy]
         # @param [boolean] assign a doi to the object
-        # @param [string] who the sunetid of the user registering the object
+        # @param [string] user_name the sunetid of the user registering the object
         # @param [boolean] validate validate the response object
         # @return [Cocina::Models::DROWithMetadata,Cocina::Models::CollectionWithMetadata,Cocina::Models::AdminPolicyWithMetadata] the returned model
-        def register(params:, assign_doi: false, validate: false, who: nil)
+        def register(params:, assign_doi: false, validate: false, user_name: nil)
           resp = connection.post do |req|
             req.url objects_path
-            req.params = { assign_doi: assign_doi, event_who: who }.compact
+            req.params = { assign_doi: assign_doi, user_name: user_name }.compact
             req.headers['Content-Type'] = 'application/json'
             # asking the service to return JSON (else it'll be plain text)
             req.headers['Accept'] = 'application/json'

--- a/spec/dor/services/client/object_spec.rb
+++ b/spec/dor/services/client/object_spec.rb
@@ -316,9 +316,6 @@ RSpec.describe Dor::Services::Client::Object do
     context 'when API request succeeds with DRO' do
       subject(:model) { client.update(params: dro_with_metadata) }
 
-      let(:who) { '' }
-      let(:description) { '' }
-
       before do
         stub_request(:patch, 'https://dor-services.example.com/v1/objects/druid:bc123df4567')
           .with(
@@ -346,13 +343,13 @@ RSpec.describe Dor::Services::Client::Object do
     end
 
     context 'when some event data is provided' do
-      subject(:model) { client.update(params: dro_with_metadata, who: who, description: description) }
+      subject(:model) { client.update(params: dro_with_metadata, user_name: who, description: description) }
 
       let(:who) { 'test_user' }
       let(:description) { 'update stuff' }
 
       before do
-        stub_request(:patch, "https://dor-services.example.com/v1/objects/druid:bc123df4567?event_description=#{description}&event_who=#{who}")
+        stub_request(:patch, "https://dor-services.example.com/v1/objects/druid:bc123df4567?event_description=#{description}&user_name=#{who}")
           .with(
             body: json,
             headers: {
@@ -374,7 +371,7 @@ RSpec.describe Dor::Services::Client::Object do
       it 'sends the event data in the patch request in the querystring' do
         expect(model.externalIdentifier).to eq 'druid:bc123df4567'
         expect(model.lock).to eq('W/"e541d8cd98f00b204e9800998ecf8427f"')
-        expect(WebMock).to have_requested(:patch, "https://dor-services.example.com/v1/objects/druid:bc123df4567?event_description=#{description}&event_who=#{who}")
+        expect(WebMock).to have_requested(:patch, "https://dor-services.example.com/v1/objects/druid:bc123df4567?event_description=#{description}&user_name=#{who}")
           .with(body: json, headers: { 'If-Match' => lock, 'Content-Type' => 'application/json', 'Accept' => 'application/json' })
       end
     end

--- a/spec/dor/services/client/objects_spec.rb
+++ b/spec/dor/services/client/objects_spec.rb
@@ -67,11 +67,11 @@ RSpec.describe Dor::Services::Client::Objects do
     end
 
     context 'when passing in the person who registered the object' do
-      let(:url) { "https://dor-services.example.com/v1/objects?assign_doi=false&event_who=#{who}" }
+      let(:url) { "https://dor-services.example.com/v1/objects?assign_doi=false&user_name=#{who}" }
       let(:who) { 'test_user' }
 
       it 'posts with who param' do
-        expect { client.register(params: request_dro, assign_doi: false, who: who) }.not_to raise_error
+        expect { client.register(params: request_dro, assign_doi: false, user_name: who) }.not_to raise_error
       end
     end
 


### PR DESCRIPTION
## Why was this change made? 🤔

I noticed where are already using "user_name" to pass to events in another spot (see https://github.com/sul-dlss/dor-services-client/blob/main/lib/dor/services/client/mutate.rb#L82), so let's make these new ones the same.  I will update DSA PR to handle it.

## How was this change tested? 🤨

Spec


