### PR TITLE
Adds support for workflow templates endpoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,9 @@ object_client.reindex
 
 # Search for administrative tags:
 Dor::Services::Client.administrative_tags.search(q: 'Project')
+
+# Get a list of workflow templates
+Dor::Services::Client.workflows.templates
 ```
 
 ## Asynchronous results

--- a/lib/dor/services/client.rb
+++ b/lib/dor/services/client.rb
@@ -116,6 +116,11 @@ module Dor
         @background_job_results ||= BackgroundJobResults.new(connection: connection, version: DEFAULT_VERSION)
       end
 
+      # @return [Dor::Services::Client::Workflows] an instance of the `Client::Workflows` class
+      def workflows
+        @workflows ||= Workflows.new(connection: connection, version: DEFAULT_VERSION)
+      end
+
       class << self
         # @param [String] url the base url of the endpoint the client should connect to (required)
         # @param [String] token a bearer token for HTTP authentication (required)
@@ -133,7 +138,7 @@ module Dor
           self
         end
 
-        delegate :background_job_results, :objects, :object, :virtual_objects, :administrative_tags, to: :instance
+        delegate :background_job_results, :objects, :object, :virtual_objects, :administrative_tags, :workflows, to: :instance
       end
 
       attr_writer :url, :token, :connection, :enable_get_retries, :logger

--- a/lib/dor/services/client/workflows.rb
+++ b/lib/dor/services/client/workflows.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Dor
+  module Services
+    class Client
+      # API calls around workflows in DOR
+      class Workflows < VersionedService
+        # Retrieves a list of workflow template name
+        # @return [Array<String>] the list of templates
+        def templates
+          resp = connection.post do |req|
+            req.url "#{api_version}/workflow_templates"
+            req.headers['Content-Type'] = 'application/json'
+            req.headers['Accept'] = 'application/json'
+          end
+          raise_exception_based_on_response!(resp) unless resp.success?
+
+          JSON.parse(resp.body)
+        end
+      end
+    end
+  end
+end

--- a/spec/dor/services/client/workflows_spec.rb
+++ b/spec/dor/services/client/workflows_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.describe Dor::Services::Client::Workflows do
+  subject(:client) { described_class.new(connection: connection, version: 'v1') }
+
+  before do
+    Dor::Services::Client.configure(url: 'https://dor-services.example.com', token: '123')
+  end
+
+  let(:connection) { Dor::Services::Client.instance.send(:connection) }
+
+  describe '#templates' do
+    before do
+      stub_request(:post, 'https://dor-services.example.com/v1/workflow_templates')
+        .with(
+          headers: { 'Content-Type' => 'application/json', 'Accept' => 'application/json' }
+        )
+        .to_return(status: status, body: body, headers: { 'Location' => 'https://dor-services.example.com/v1/background_job_results/123' })
+    end
+
+    context 'when API request succeeds' do
+      let(:status) { 200 }
+      let(:templates) { %w[assemblyWF registrationWF] }
+      let(:body) { templates.to_json }
+
+      it 'returns templates' do
+        expect(client.templates).to eq(templates)
+      end
+    end
+
+    context 'when API request fails' do
+      let(:status) { [500] }
+      let(:body) { '{"errors":["error message here"]}' }
+
+      it 'raises an error' do
+        expect { client.templates }.to raise_error(Dor::Services::Client::UnexpectedResponse)
+      end
+    end
+  end
+end

--- a/spec/dor/services/client_spec.rb
+++ b/spec/dor/services/client_spec.rb
@@ -54,6 +54,16 @@ RSpec.describe Dor::Services::Client do
       end
     end
 
+    describe '.workflows' do
+      it 'returns an instance of Client::Workflows' do
+        expect(described_class.workflows).to be_instance_of Dor::Services::Client::Workflows
+      end
+
+      it 'returns the memoized instance when called again' do
+        expect(described_class.workflows).to eq described_class.workflows
+      end
+    end
+
     describe '.background_job_results' do
       it 'returns an instance of Client::BackgroundJobResults' do
         expect(described_class.background_job_results).to be_instance_of Dor::Services::Client::BackgroundJobResults


### PR DESCRIPTION
closes #532

## Why was this change made? 🤔
So that apps can use this instead of workflow client.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



