### PR TITLE
add workflow status method

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ object_client.workflow('etdSubmitWF').create(version: 2)
 # Skip all workflow steps
 object_client.workflow('accessionWF').skip_all(note: 'Cleaning up')
 
+# Get the status of a workflow process
+object_client.workflow('accessionWF').process('shelve').status
+=> 'completed'
+
 # Update workflow processes
 object_client.workflow('accessionWF').process('shelve').update(status: 'completed')
 object_client.workflow('accessionWF').process('shelve').update_error(error_msg: 'Something went wrong', error_text: 'Detailed error message')

--- a/lib/dor/services/client/process.rb
+++ b/lib/dor/services/client/process.rb
@@ -15,6 +15,17 @@ module Dor
           @process = process
         end
 
+        # Gets the status of one step in a workflow.
+        def status
+          resp = connection.get do |req|
+            req.url "#{api_version}/objects/#{object_identifier}/workflows/#{workflow_name}/processes/#{process}"
+            req.headers['Content-Type'] = 'application/json'
+          end
+
+          raise_exception_based_on_response!(resp) unless resp.success?
+          JSON.parse(resp.body)['status']
+        end
+
         # Updates the status of one step in a workflow.
         # @param [String] status The status of the process.
         # @param [Float] elapsed The number of seconds it took to complete this step. Can have a decimal.  Is set to 0 if not passed in.

--- a/spec/dor/services/client/process_spec.rb
+++ b/spec/dor/services/client/process_spec.rb
@@ -6,21 +6,50 @@ RSpec.describe Dor::Services::Client::Process do
                         workflow_name: 'accessionWF', process: 'shelve')
   end
 
-  before do
-    Dor::Services::Client.configure(url: 'https://dor-services.example.com', token: '123', enable_get_retries: false)
-    stub_request(:put, 'https://dor-services.example.com/v1/objects/druid:mw971zk1113/workflows/accessionWF/processes/shelve')
-      .with(
-        headers: { 'Content-Type' => 'application/json' },
-        body: body
-      )
-      .to_return(status: status)
-  end
-
   let(:connection) { Dor::Services::Client.instance.send(:connection) }
-  let(:status) { 204 }
   let(:druid) { 'druid:mw971zk1113' }
 
+  describe '#status' do
+    let(:status) { 200 }
+    let(:workflow_status) { 'completed' }
+
+    before do
+      Dor::Services::Client.configure(url: 'https://dor-services.example.com', token: '123', enable_get_retries: false)
+      stub_request(:get, 'https://dor-services.example.com/v1/objects/druid:mw971zk1113/workflows/accessionWF/processes/shelve')
+        .with(
+          headers: { 'Content-Type' => 'application/json' }
+        )
+        .to_return(status: status, body: { status: workflow_status }.to_json)
+    end
+
+    context 'when API request succeeds' do
+      it 'returns the status' do
+        expect(client.status).to eq workflow_status
+      end
+    end
+
+    context 'when API request returns 404' do
+      let(:status) { [404, 'not found'] }
+
+      it 'raises a NotFoundResponse exception' do
+        expect { client.status }.to raise_error(Dor::Services::Client::NotFoundResponse)
+      end
+    end
+  end
+
   describe '#update' do
+    let(:status) { 204 }
+
+    before do
+      Dor::Services::Client.configure(url: 'https://dor-services.example.com', token: '123', enable_get_retries: false)
+      stub_request(:put, 'https://dor-services.example.com/v1/objects/druid:mw971zk1113/workflows/accessionWF/processes/shelve')
+        .with(
+          headers: { 'Content-Type' => 'application/json' },
+          body: body
+        )
+        .to_return(status: status)
+    end
+
     context 'when API request succeeds' do
       let(:body) do
         {
@@ -67,12 +96,23 @@ RSpec.describe Dor::Services::Client::Process do
   end
 
   describe '#update_error' do
+    let(:status) { 204 }
     let(:body) do
       {
         status: 'error',
         error_msg: 'Ooops',
         error_text: 'the backtrace'
       }
+    end
+
+    before do
+      Dor::Services::Client.configure(url: 'https://dor-services.example.com', token: '123', enable_get_retries: false)
+      stub_request(:put, 'https://dor-services.example.com/v1/objects/druid:mw971zk1113/workflows/accessionWF/processes/shelve')
+        .with(
+          headers: { 'Content-Type' => 'application/json' },
+          body: body
+        )
+        .to_return(status: status)
     end
 
     it 'does not raise' do


### PR DESCRIPTION
## Why was this change made? 🤔

Add the method which calls the new DSA route added [here](https://github.com/sul-dlss/dor-services-app/pull/5412) to fetch the status of a single workflow process.

Requires https://github.com/sul-dlss/dor-services-app/pull/5412 first


## How was this change tested? 🤨

Specs



