### PR TITLE
Memoize object workflow instance only when workflow name matches

### DIFF
--- a/lib/dor/services/client/object.rb
+++ b/lib/dor/services/client/object.rb
@@ -55,7 +55,14 @@ module Dor
         end
 
         def workflow(workflow_name)
-          @workflow ||= ObjectWorkflow.new(**parent_params.merge({ workflow_name: workflow_name }))
+          raise ArgumentError, '`workflow_name` argument cannot be blank in call to `#workflow(workflow_name)' if workflow_name.blank?
+
+          # Return memoized object instance if workflow_name value is the same
+          #
+          # This allows the client to interact with multiple workflows for a given object
+          return @workflow if @workflow&.workflow_name == workflow_name
+
+          @workflow = ObjectWorkflow.new(**parent_params.merge({ workflow_name: workflow_name }))
         end
 
         # Retrieves the Cocina model

--- a/lib/dor/services/client/object_workflow.rb
+++ b/lib/dor/services/client/object_workflow.rb
@@ -5,6 +5,8 @@ module Dor
     class Client
       # API calls around workflow for an object.
       class ObjectWorkflow < VersionedService
+        attr_reader :workflow_name
+
         # @param object_identifier [String] the druid for the object
         # @param [String] workflow_name The name of the workflow
         def initialize(connection:, version:, object_identifier:, workflow_name:)
@@ -61,7 +63,7 @@ module Dor
 
         private
 
-        attr_reader :object_identifier, :workflow_name
+        attr_reader :object_identifier
       end
     end
   end

--- a/spec/dor/services/client/object_spec.rb
+++ b/spec/dor/services/client/object_spec.rb
@@ -106,12 +106,9 @@ RSpec.describe Dor::Services::Client::Object do
   describe '#workflow' do
     let(:object_workflow) { instance_double(Dor::Services::Client::ObjectWorkflow) }
 
-    before do
-      allow(Dor::Services::Client::ObjectWorkflow).to receive(:new).and_return(object_workflow)
-    end
-
     it 'returns an instance of Client::ObjectWorkflow' do
-      client.workflow('accessionWF')
+      # This is not in a `before` block because the other tests in the `describe` block don't rely on this being spied on
+      allow(Dor::Services::Client::ObjectWorkflow).to receive(:new).and_return(object_workflow)
       expect(client.workflow('accessionWF')).to be object_workflow
       expect(Dor::Services::Client::ObjectWorkflow).to have_received(:new).with(
         connection: connection,
@@ -119,6 +116,24 @@ RSpec.describe Dor::Services::Client::Object do
         object_identifier: druid,
         workflow_name: 'accessionWF'
       )
+    end
+
+    context 'when called with a different workflow name' do
+      it 'refreshes the memoized instance' do
+        expect(client.workflow('accessionWF')).not_to eq client.workflow('registrationWF')
+      end
+    end
+
+    context 'when called with nil workflow name' do
+      it 'raises an ArgumentError' do
+        expect { client.workflow(nil) }.to raise_error(ArgumentError, /`workflow_name` argument cannot be blank/)
+      end
+    end
+
+    context 'when called with blank workflow name' do
+      it 'raises an ArgumentError' do
+        expect { client.workflow('') }.to raise_error(ArgumentError, /`workflow_name` argument cannot be blank/)
+      end
     end
   end
 


### PR DESCRIPTION
Else when we ask for `#workflow(accessionWF)` after already asking for `#workflow(registrationWF)`, we still get the latter.

## Why was this change made? 🤔



## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



