### PR TITLE
Fix HTTP method for DSA workflow templates endpoint

### DIFF
--- a/lib/dor/services/client/workflows.rb
+++ b/lib/dor/services/client/workflows.rb
@@ -8,7 +8,7 @@ module Dor
         # Retrieves a list of workflow template name
         # @return [Array<String>] the list of templates
         def templates
-          resp = connection.post do |req|
+          resp = connection.get do |req|
             req.url "#{api_version}/workflow_templates"
             req.headers['Content-Type'] = 'application/json'
             req.headers['Accept'] = 'application/json'

--- a/spec/dor/services/client/workflows_spec.rb
+++ b/spec/dor/services/client/workflows_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Dor::Services::Client::Workflows do
 
   describe '#templates' do
     before do
-      stub_request(:post, 'https://dor-services.example.com/v1/workflow_templates')
+      stub_request(:get, 'https://dor-services.example.com/v1/workflow_templates')
         .with(
           headers: { 'Content-Type' => 'application/json', 'Accept' => 'application/json' }
         )


### PR DESCRIPTION
# Why was this change made? 

`Dor::Services::Client.workflows.templates` is currently busted.

# How was this change tested?

CI, QA

