### PR TITLE
Fix bug in workflow response

### DIFF
--- a/lib/dor/services/response/workflows.rb
+++ b/lib/dor/services/response/workflows.rb
@@ -5,32 +5,26 @@ module Dor
     module Response
       # The response from asking the server about all workflows for an item
       class Workflows
+        attr_reader :xml
+
+        # @param [Nokogiri::XML] xml Nokogiri XML document showing all workflows
         def initialize(xml:)
           @xml = xml
         end
 
         def pid
-          ng_xml.at_xpath('/workflows/@objectId').text
+          xml.at_xpath('/workflows/@objectId').text
         end
 
         def workflows
-          @workflows ||= ng_xml.xpath('/workflows/workflow').map do |node|
+          @workflows ||= xml.xpath('/workflows/workflow').map do |node|
             Workflow.new(xml: node.to_xml)
           end
         end
 
-        # @return [Array<String>] returns a list of errors for any process for the current version
+        # @return [Array<String>] returns a list of errors for any process for the specified version
         def errors_for(version:)
-          ng_xml.xpath("//workflow/process[@version='#{version}' and @status='error']/@errorMessage")
-                .map(&:text)
-        end
-
-        attr_reader :xml
-
-        private
-
-        def ng_xml
-          @ng_xml ||= Nokogiri::XML(@xml)
+          xml.xpath("//workflow/process[@version='#{version}' and @status='error']/@errorMessage").map(&:text)
         end
       end
     end

--- a/spec/dor/services/response/workflows_spec.rb
+++ b/spec/dor/services/response/workflows_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe Dor::Services::Response::Workflows do
-  subject(:instance) { described_class.new(xml: xml) }
+  subject(:instance) { described_class.new(xml: Nokogiri::XML(xml)) }
 
   describe '#pid' do
     subject { instance.pid }


### PR DESCRIPTION
# Why was this change made?

`Dor::Services::Response::Workflows` is busted because the XML is already a NG doc.

# How was this change tested?

CI, QA

