### PR TITLE
Make sure workflow response object is passed a string instead of an NG doc

### DIFF
--- a/lib/dor/services/client/object_workflow.rb
+++ b/lib/dor/services/client/object_workflow.rb
@@ -30,7 +30,7 @@ module Dor
 
           raise_exception_based_on_response!(resp) unless resp.success?
 
-          Dor::Services::Response::Workflow.new(xml: Nokogiri::XML(resp.body))
+          Dor::Services::Response::Workflow.new(xml: resp.body)
         end
 
         # Creates a workflow for a given object in the repository.  If this particular workflow for this objects exists,

--- a/lib/dor/services/response/workflow.rb
+++ b/lib/dor/services/response/workflow.rb
@@ -5,6 +5,7 @@ module Dor
     module Response
       # The response from asking the server about a workflow for an item
       class Workflow
+        # @param [String] xml An XML string representing a given workflow
         def initialize(xml:)
           @xml = xml
         end

--- a/spec/dor/services/client/object_workflow_spec.rb
+++ b/spec/dor/services/client/object_workflow_spec.rb
@@ -9,8 +9,6 @@ RSpec.describe Dor::Services::Client::ObjectWorkflow do
 
   let(:connection) { Dor::Services::Client.instance.send(:connection) }
   let(:druid) { 'druid:mw971zk1113' }
-
-  let(:ng_xml) { Nokogiri::XML(xml) }
   let(:xml) do
     <<~XML
       <workflow repository="dor" objectId="druid:mw971zk1113" id="accessionWF">
@@ -20,7 +18,7 @@ RSpec.describe Dor::Services::Client::ObjectWorkflow do
   end
 
   describe '#find' do
-    subject(:workflows) { client.find }
+    subject(:workflow) { client.find }
 
     before do
       stub_request(:get, 'https://dor-services.example.com/v1/objects/druid:mw971zk1113/workflows/accessionWF')
@@ -31,8 +29,8 @@ RSpec.describe Dor::Services::Client::ObjectWorkflow do
       let(:status) { 200 }
       let(:body) { xml }
 
-      it 'returns the workflows' do
-        expect(workflows).to be_a(Dor::Services::Response::Workflow)
+      it 'returns the workflow' do
+        expect(workflow).to be_a(Dor::Services::Response::Workflow)
       end
     end
 
@@ -41,7 +39,7 @@ RSpec.describe Dor::Services::Client::ObjectWorkflow do
       let(:body) { '' }
 
       it 'raises a NotFoundResponse exception' do
-        expect { workflows }.to raise_error(Dor::Services::Client::NotFoundResponse)
+        expect { workflow }.to raise_error(Dor::Services::Client::NotFoundResponse)
       end
     end
   end


### PR DESCRIPTION
This fixes a bug that I turned up while testing Argo.

