### PR TITLE
Expose DSA find_all endpoint via client

### DIFF
--- a/lib/dor/services/client/mutate.rb
+++ b/lib/dor/services/client/mutate.rb
@@ -55,7 +55,7 @@ module Dor
 
           raise_exception_based_on_response!(resp) unless resp.success?
 
-          build_cocina_from_response(resp, validate: validate)
+          build_cocina_from_response(JSON.parse(resp.body), headers: resp.headers, validate: validate)
         end
         # rubocop:enable Metrics/AbcSize
         # rubocop:enable Metrics/MethodLength

--- a/lib/dor/services/client/object.rb
+++ b/lib/dor/services/client/object.rb
@@ -76,7 +76,7 @@ module Dor
           end
           raise_exception_based_on_response!(resp) unless resp.success?
 
-          build_cocina_from_response(resp, validate: validate)
+          build_cocina_from_response(JSON.parse(resp.body), headers: resp.headers, validate: validate)
         end
 
         BASE_ALLOWED_FIELDS = %i[external_identifier cocina_version label version administrative description].freeze

--- a/lib/dor/services/client/object_version.rb
+++ b/lib/dor/services/client/object_version.rb
@@ -61,7 +61,7 @@ module Dor
           end
           raise_exception_based_on_response!(resp) unless resp.success?
 
-          build_cocina_from_response(resp, validate: false)
+          build_cocina_from_response(JSON.parse(resp.body), headers: resp.headers, validate: false)
         end
 
         # Get the current version for a DOR object. This comes from ObjectVersion table in the DSA
@@ -93,7 +93,7 @@ module Dor
 
           raise_exception_based_on_response!(resp) unless resp.success?
 
-          build_cocina_from_response(resp)
+          build_cocina_from_response(JSON.parse(resp.body), headers: resp.headers)
         end
 
         # Close current version for an object

--- a/lib/dor/services/client/user_version.rb
+++ b/lib/dor/services/client/user_version.rb
@@ -44,7 +44,7 @@ module Dor
           end
           raise_exception_based_on_response!(resp) unless resp.success?
 
-          build_cocina_from_response(resp, validate: false)
+          build_cocina_from_response(JSON.parse(resp.body), headers: resp.headers, validate: false)
         end
 
         # @return [Hash] the solr document for the user version

--- a/lib/dor/services/client/versioned_service.rb
+++ b/lib/dor/services/client/versioned_service.rb
@@ -41,18 +41,20 @@ module Dor
                                     errors: data.fetch('errors', []))
         end
 
-        def build_cocina_from_response(response, validate: false)
-          cocina_object = Cocina::Models.build(JSON.parse(response.body), validate: validate)
-          Cocina::Models.with_metadata(cocina_object, response.headers['ETag'], created: date_from_header(response, 'X-Created-At'),
-                                                                                modified: date_from_header(response, 'Last-Modified'))
+        def build_cocina_from_response(item, headers: nil, validate: false)
+          cocina_object = Cocina::Models.build(item, validate: validate)
+          return Cocina::Models.without_metadata(cocina_object) unless headers.present?
+
+          Cocina::Models.with_metadata(cocina_object, headers['ETag'], created: date_from_header(headers, 'X-Created-At'),
+                                                                       modified: date_from_header(headers, 'Last-Modified'))
         end
 
         def build_json_from_cocina(cocina_object)
           Cocina::Models.without_metadata(cocina_object).to_json
         end
 
-        def date_from_header(response, key)
-          response.headers[key]&.to_datetime
+        def date_from_header(headers, key)
+          headers[key]&.to_datetime
         end
       end
     end

--- a/spec/dor/services/client/objects_spec.rb
+++ b/spec/dor/services/client/objects_spec.rb
@@ -178,6 +178,41 @@ RSpec.describe Dor::Services::Client::Objects do
     end
   end
 
+  describe '#find_all' do
+    subject(:model) { client.find_all(druids: druids, validate: validate) }
+
+    let(:druids) { ['druid:bc123df4567', 'druid:bc987gh6543'] }
+    let(:cocina) { [build(:dro_with_metadata, id: 'druid:bc123df4567'), build(:dro_with_metadata, id: 'druid:bc987gh6543')] }
+    let(:validate) { false }
+    let(:status) { 200 }
+
+    before do
+      stub_request(:post, 'https://dor-services.example.com/v1/objects/find_all')
+        .with(
+          body: { externalIdentifiers: druids }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+        .to_return(status: status,
+                   body: cocina.to_json)
+    end
+
+    context 'when API request succeeds with DRO' do
+      it 'returns an array of cocina models' do
+        expect(model.first.externalIdentifier).to eq 'druid:bc123df4567'
+        expect(model.last.externalIdentifier).to eq 'druid:bc987gh6543'
+      end
+    end
+
+    context 'when API request returns an empty array' do
+      let(:cocina) { [] }
+
+      it 'returns an empty array' do
+        expect(model).to be_an(Array)
+        expect(model).to be_empty
+      end
+    end
+  end
+
   describe '#statuses' do
     subject(:statuses) { client.statuses(object_ids: ['druid:bc123df4567', 'druid:bc987gh6543']) }
 


### PR DESCRIPTION
## Why was this change made? 🤔

Part of https://github.com/sul-dlss/argo/issues/4824

This required a small change to `build_cocina_from_response` to take the response body and headers as separate  parameters instead of getting them from a single response object so that we can pass in each individual object returned from `find_all`


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



