### PR TITLE
Do not pass an empty array on to dor-services-app

### DIFF
--- a/lib/dor/services/client/objects.rb
+++ b/lib/dor/services/client/objects.rb
@@ -46,7 +46,9 @@ module Dor
         # Find objects by a list of druids
         # @raise [UnexpectedResponse] when the response is not successful.
         # @return [Array<Cocina::Models::DROWithMetadata,Cocina::Models::CollectionWithMetadata,,Cocina::Models::AdminPolicyWithMetadata>] the returned objects
-        def find_all(druids:, validate: false)
+        def find_all(druids:, validate: false) # rubocop:disable Metrics/AbcSize
+          return [] if druids.empty?
+
           resp = connection.post do |req|
             req.url "#{objects_path}/find_all"
             req.headers['Content-Type'] = 'application/json'

--- a/spec/dor/services/client/objects_spec.rb
+++ b/spec/dor/services/client/objects_spec.rb
@@ -211,6 +211,16 @@ RSpec.describe Dor::Services::Client::Objects do
         expect(model).to be_empty
       end
     end
+
+    context 'when druids is empty, return an empty array' do
+      let(:druids) { [] }
+      let(:cocina) { [] }
+
+      it 'returns an empty array' do
+        expect(model).to be_an(Array)
+        expect(model).to be_empty
+      end
+    end
   end
 
   describe '#statuses' do


### PR DESCRIPTION
## Why was this change made? 🤔

Quick fix to avoid sending an empty array to dor-services-app

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



