### PR TITLE
Adds new solr endpoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ object_client.collections
 # Query for a collection's members
 object_client.members
 
+# Returns the solr document for the head version.
+object_client.solr(validate: false)
+
 # Create, update, destroy, and list administrative tags for an object
 object_client.administrative_tags.create(tags: ['Tag : One', 'Tag : Two'])
 object_client.administrative_tags.replace(tags: ['Tag : One', 'Tag : Two']) # like #create but removes current tags first

--- a/lib/dor/services/client/object.rb
+++ b/lib/dor/services/client/object.rb
@@ -183,6 +183,17 @@ module Dor
         end
         # rubocop:enable Metrics/MethodLength
 
+        # @return [Hash] the solr document for the head version
+        # @raise [UnexpectedResponse] on an unsuccessful response from the server
+        def solr(validate: true)
+          resp = connection.get do |req|
+            req.url "#{object_path}/solr?validate=#{validate}"
+          end
+          raise_exception_based_on_response!(resp) unless resp.success?
+
+          JSON.parse(resp.body)
+        end
+
         private
 
         def parent_params

--- a/spec/dor/services/client/object_spec.rb
+++ b/spec/dor/services/client/object_spec.rb
@@ -652,4 +652,39 @@ RSpec.describe Dor::Services::Client::Object do
       end
     end
   end
+
+  describe '#solr' do
+    subject(:solr) { client.solr(validate: validate) }
+
+    let(:expected_solr) do
+      {
+        'id' => druid,
+        'current_version_isi' => 1,
+        'obj_label_tesim' => 'Test DRO',
+        'modified_latest_dttsi' => '2024-07-03T12:32:16Z',
+        'created_at_dttsi' => '2024-07-03T12:32:16Z',
+        'is_governed_by_ssim' => 'info:fedora/druid:hy787xj5878',
+        'objectType_ssim' => ['item']
+      }
+    end
+    let(:validate) { true }
+
+    before do
+      stub_request(:get, "https://dor-services.example.com/v1/objects/druid:bc123df4567/solr?validate=#{validate}")
+        .to_return(status: 200,
+                   body: expected_solr.to_json)
+    end
+
+    it 'returns the solr document' do
+      expect(solr).to eq expected_solr
+    end
+
+    context 'with validation turned off' do
+      let(:validate) { false }
+
+      it 'returns the solr document' do
+        expect(solr).to eq expected_solr
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made? 🤔
Allow getting a solr doc that is built on the fly.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



