### PR TITLE
Adds lane_id to release tags create.

### DIFF
--- a/lib/dor/services/client/release_tags.rb
+++ b/lib/dor/services/client/release_tags.rb
@@ -14,14 +14,16 @@ module Dor
         # Create a release tag for an object
         #
         # @param tag [ReleaseTag]
+        # @param lane_id [String, nil] optional lane id for the releaseWF
         # @return [Boolean] true if successful
         # @raise [NotFoundResponse] when the response is a 404 (object not found)
         # @raise [UnexpectedResponse] if the request is unsuccessful.
-        def create(tag:)
+        def create(tag:, lane_id: nil)
           resp = connection.post do |req|
             req.url "#{api_version}/objects/#{object_identifier}/release_tags"
             req.headers['Content-Type'] = 'application/json'
             req.body = tag.to_json
+            req.params['lane-id'] = lane_id if lane_id
           end
           raise_exception_based_on_response!(resp, object_identifier) unless resp.success?
 

--- a/spec/dor/services/client/release_tags_spec.rb
+++ b/spec/dor/services/client/release_tags_spec.rb
@@ -61,15 +61,30 @@ RSpec.describe Dor::Services::Client::ReleaseTags do
   end
 
   describe '#create' do
-    subject(:request) { client.create(tag: tag) }
+    subject(:request) { client.create(tag: tag, lane_id: lane_id) }
 
     let(:tag) do
       Dor::Services::Client::ReleaseTag.new(what: 'self')
     end
 
+    let(:lane_id) { nil }
+
     context 'when API request succeeds' do
       before do
         stub_request(:post, "https://dor-services.example.com/v1/objects/#{druid}/release_tags")
+          .to_return(status: 201)
+      end
+
+      it 'posts tag' do
+        expect(request).to be true
+      end
+    end
+
+    context 'when API request with a lane id' do
+      let(:lane_id) { 'low' }
+
+      before do
+        stub_request(:post, "https://dor-services.example.com/v1/objects/#{druid}/release_tags?lane-id=low")
           .to_return(status: 201)
       end
 


### PR DESCRIPTION
refs https://github.com/sul-dlss/dor-services-app/issues/5959

## Why was this change made? 🤔
So that Argo bulk action can create tags on the low queue.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



