### PR TITLE
Adds lane-id to close version endpoint.

### DIFF
--- a/lib/dor/services/client/object_version.rb
+++ b/lib/dor/services/client/object_version.rb
@@ -106,11 +106,13 @@ module Dor
         # @param description [String] (optional) - a description of the object version being opened
         # @param user_name [String] (optional) - sunetid
         # @param start_accession [Boolean] (optional) - whether to start accessioning workflow; defaults to true
+        # @param lane_id [String] (optional) - lane id to use for accessioning workflow ('low', 'default', 'high')
         # @param user_versions [String] (optional - values are none, new, or update) - create, update, or do nothing with user versions on close; defaults to none.
         # @raise [NotFoundResponse] when the response is a 404 (object not found)
         # @raise [UnexpectedResponse] when the response is not successful.
         # @return [String] a message confirming successful closing
         def close(**params)
+          params['lane-id'] = params.delete(:lane_id) if params.key?(:lane_id)
           resp = connection.post do |req|
             req.url close_version_path
             req.params = params.compact

--- a/spec/dor/services/client/object_version_spec.rb
+++ b/spec/dor/services/client/object_version_spec.rb
@@ -604,10 +604,10 @@ RSpec.describe Dor::Services::Client::ObjectVersion do
     context 'with additional params' do
       let(:status) { 200 }
       let(:body) { 'version 2 closed' }
-      let(:params) { { user_name: 'lelands', description: nil } }
+      let(:params) { { user_name: 'lelands', description: nil, lane_id: 'high' } }
 
       before do
-        stub_request(:post, 'https://dor-services.example.com/v1/objects/druid:bc123df4567/versions/current/close?user_name=lelands')
+        stub_request(:post, 'https://dor-services.example.com/v1/objects/druid:bc123df4567/versions/current/close?user_name=lelands&lane-id=high')
           .with(headers: { 'Content-Type' => 'application/json' })
           .to_return(status: status, body: body)
       end


### PR DESCRIPTION
refs https://github.com/sul-dlss/dor-services-app/issues/5973

## Why was this change made? 🤔
To allow specifying the lane when accessioning.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



