### PR TITLE
allow version to be passed into client calls for updating workflow steps

### DIFF
--- a/lib/dor/services/client/process.rb
+++ b/lib/dor/services/client/process.rb
@@ -32,16 +32,19 @@ module Dor
         # @param [String] lifecycle Bookeeping label for this particular workflow step.  Examples are: 'registered', 'shelved'
         # @param [String] note Any kind of string annotation that you want to attach to the workflow
         # @param [String] current_status Setting this string tells the workflow service to compare the current status to this value.
+        # @param [String,Integer] version The object version this workflow step belongs to. If not provided, the step for the latest version is updated.
         # @raise [Dor::Services::Client::ConflictResponse] if the current status does not match the value passed in current_status.
-        def update(status:, elapsed: 0, lifecycle: nil, note: nil, current_status: nil)
-          perform_update(status: status, elapsed: elapsed, lifecycle: lifecycle, note: note, current_status: current_status)
+        def update(status:, elapsed: 0, lifecycle: nil, note: nil, current_status: nil, version: nil) # rubocop:disable Metrics/ParameterLists
+          perform_update(status: status, elapsed: elapsed, lifecycle: lifecycle, note: note, current_status: current_status,
+                         version: version)
         end
 
         # Updates the status of one step in a workflow to error.
         # @param [String] error_msg The error message.  Ideally, this is a brief message describing the error
         # @param [String] error_text A slot to hold more information about the error, like a full stacktrace
-        def update_error(error_msg:, error_text: nil)
-          perform_update(status: 'error', error_msg: error_msg, error_text: error_text)
+        # @param [String,Integer] version The object version this workflow step belongs to. If not provided, the step for the latest version is updated.
+        def update_error(error_msg:, error_text: nil, version: nil)
+          perform_update(status: 'error', error_msg: error_msg, error_text: error_text, version: version)
         end
 
         attr_reader :object_identifier, :workflow_name, :process, :object_workflow_client

--- a/spec/dor/services/client/process_spec.rb
+++ b/spec/dor/services/client/process_spec.rb
@@ -66,6 +66,20 @@ RSpec.describe Dor::Services::Client::Process do
         expect { client.update(status: 'completed', current_status: 'started') }.to raise_error(Dor::Services::Client::ConflictResponse)
       end
     end
+
+    context 'when API request succeeds with a version' do
+      let(:body) do
+        {
+          status: 'completed',
+          elapsed: 0,
+          version: 2
+        }
+      end
+
+      it 'does not raise' do
+        expect { client.update(status: 'completed', version: 2) }.not_to raise_error
+      end
+    end
   end
 
   describe '#update_error' do
@@ -79,6 +93,21 @@ RSpec.describe Dor::Services::Client::Process do
 
     it 'does not raise' do
       expect { client.update_error(error_msg: 'Ooops', error_text: 'the backtrace') }.not_to raise_error
+    end
+
+    context 'when a version is provided' do
+      let(:body) do
+        {
+          status: 'error',
+          error_msg: 'Ooops',
+          error_text: 'the backtrace',
+          version: 2
+        }
+      end
+
+      it 'does not raise' do
+        expect { client.update_error(error_msg: 'Ooops', error_text: 'the backtrace', version: 2) }.not_to raise_error
+      end
     end
   end
 


### PR DESCRIPTION
## Why was this change made? 🤔

Part of https://github.com/sul-dlss/dor-services-app/issues/6172

Goes with https://github.com/sul-dlss/dor-services-app/pull/6196 and https://github.com/sul-dlss/lyber-core/pull/297

## How was this change tested? 🤨

Specs




