### PR TITLE
Remove label as an allowed field for graphql.

### DIFF
--- a/lib/dor/services/client/object.rb
+++ b/lib/dor/services/client/object.rb
@@ -91,9 +91,6 @@ module Dor
           resp.headers['ETag']
         end
 
-        BASE_ALLOWED_FIELDS = %i[external_identifier cocina_version label version administrative description].freeze
-        DRO_ALLOWED_FIELDS = BASE_ALLOWED_FIELDS + %i[content_type access identification structural geographic]
-
         # rubocop:disable Metrics/MethodLength
         # rubocop:disable Metrics/AbcSize
         # rubocop:disable Metrics/CyclomaticComplexity


### PR DESCRIPTION
refs https://github.com/sul-dlss/dor-services-app/issues/6184

## Why was this change made? 🤔
label is being removed as a field from graphql api.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



