### PR TITLE
add active to response

### DIFF
--- a/lib/dor/services/response/process.rb
+++ b/lib/dor/services/response/process.rb
@@ -52,6 +52,10 @@ module Dor
           @attributes[:version]&.to_i
         end
 
+        def active_version?
+          @attributes[:activeVersion] == 'true'
+        end
+
         # @return [Hash] the context for the process (or empty hash if none present)
         def context
           return {} unless @attributes[:context].present?

--- a/lib/dor/services/response/workflow.rb
+++ b/lib/dor/services/response/workflow.rb
@@ -37,6 +37,12 @@ module Dor
           to_process(node)
         end
 
+        # Returns the process for the specific version and name:
+        def process_for(name:, version:)
+          node = ng_xml.at_xpath("/workflow/process[@name = '#{name}' and @version = #{version}]")
+          to_process(node)
+        end
+
         # @return [Array<String>] returns a list of all processes
         def processes
           ng_xml.xpath('/workflow/process').map { |node| to_process(node) }

--- a/spec/dor/services/response/process_spec.rb
+++ b/spec/dor/services/response/process_spec.rb
@@ -104,4 +104,44 @@ RSpec.describe Dor::Services::Response::Process do
 
     it { is_expected.to eq 3 }
   end
+
+  describe '#active_version?' do
+    subject { instance.active_version? }
+
+    context 'when activeVersion is true' do
+      let(:xml) do
+        <<~XML
+          <workflow repository="dor" objectId="druid:mw971zk1113" id="assemblyWF">
+            <process name="start-assembly" version="2" activeVersion="true">
+          </workflow>
+        XML
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context 'when activeVersion is false' do
+      let(:xml) do
+        <<~XML
+          <workflow repository="dor" objectId="druid:mw971zk1113" id="assemblyWF">
+            <process name="start-assembly" version="2" activeVersion="false">
+          </workflow>
+        XML
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context 'when activeVersion is not present' do
+      let(:xml) do
+        <<~XML
+          <workflow repository="dor" objectId="druid:mw971zk1113" id="assemblyWF">
+            <process name="start-assembly" version="2">
+          </workflow>
+        XML
+      end
+
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/dor/services/response/workflow_spec.rb
+++ b/spec/dor/services/response/workflow_spec.rb
@@ -244,6 +244,41 @@ RSpec.describe Dor::Services::Response::Workflow do
     end
   end
 
+  describe '#process_for' do
+    subject(:process) { instance.process_for(name: name, version: version) }
+
+    let(:name) { 'jp2-create' }
+    let(:version) { 2 }
+    let(:xml) do
+      <<~XML
+        <workflow repository="dor" objectId="druid:mw971zk1113" id="assemblyWF">
+          <process version="1" laneId="default" elapsed="0.509" attempts="1" datetime="2013-02-18T14:42:24-0800" status="completed" name="jp2-create"/>
+          <process version="2" laneId="default" elapsed="0.509" attempts="1" datetime="2013-02-18T14:42:24-0800" status="error" name="jp2-create" errorMessage="it just broke"/>
+          <process version="2" laneId="default" elapsed="0.509" attempts="1" datetime="2013-02-18T14:42:24-0800" status="waiting" name="start-assembly"/>
+        </workflow>
+      XML
+    end
+
+    it 'returns the process matching the provided name and version' do
+      expect(process).to be_a Dor::Services::Response::Process
+      expect(process.name).to eq 'jp2-create'
+      expect(process.version).to eq 2
+      expect(process.status).to eq 'error'
+      expect(process.error_message).to eq 'it just broke'
+    end
+
+    context 'when no process matches the name and version' do
+      let(:name) { 'does-not-exist' }
+
+      it 'returns an empty process object' do
+        expect(process).to be_a Dor::Services::Response::Process
+        expect(process.name).to be_nil
+        expect(process.status).to be_nil
+        expect(process.version).to be_nil
+      end
+    end
+  end
+
   describe '#processes' do
     subject(:processes) { instance.processes }
 


### PR DESCRIPTION
## Why was this change made? 🤔

Now that we have added the active_version attribute to the workflow step response in DSA (see https://github.com/sul-dlss/dor-services-app/pull/6220), we can add to the dsa-client.

Once merged, will cut new release of dsa-client, then move to lyber-core to use this new client to update the skipping logic. 

Then cut new release of lyber-core, and go back to DSA to use it.

## How was this change tested? 🤨

Specs